### PR TITLE
Add pt_BR docs and translations

### DIFF
--- a/addon/doc/pt_BR/readme.md
+++ b/addon/doc/pt_BR/readme.md
@@ -1,0 +1,392 @@
+# YoutubePlus para NVDA
+
+> O YoutubePlus é um complemento para usuários do NVDA que adoram o YouTube, mas consideram muitos recursos do site difíceis de acessar — como ler comentários, acompanhar canais ou monitorar o chat ao vivo.
+>
+> Trazemos esses recursos para a interface de usuário do NVDA em um formato de fácil navegação pelo teclado, com suporte a atalhos e totalmente personalizável — **sem a necessidade de chaves de API ou login em contas do Google/YouTube**.
+>
+> Você pode acompanhar seus canais favoritos e ter a certeza de que verá todos os vídeos deles, sem que o algoritmo do YouTube os filtre. Um sistema de Favoritos está incluso para vídeos, canais, playlists, além de uma Lista de Assistir Mais Tarde para salvar conteúdos nos quais você tem interesse, mas ainda não teve tempo de assistir.
+>
+> Há uma busca de vídeos integrada que exibe os resultados na própria interface do complemento — e não apenas uma caixa de pesquisa que abre o YouTube no navegador. Uma função de download está inclusa para salvar vídeos e áudios por conveniência — se o download for a sua necessidade principal, recomenda-se o uso de ferramentas dedicadas.
+>
+> O que este complemento **não** faz é embutir um reprodutor de vídeo. Acreditamos que o reprodutor web do YouTube já é acessível o suficiente por si só. Se você ainda achar que ele deixa a desejar, pode utilizar outros complementos, como o [browserNav](https://addonstore.nvaccess.org/?channel=stable&language=en&apiVersion=2025.3.2&addonId=browsernav), para melhorar a experiência.
+
+---
+
+## Sumário
+
+- [Atalhos de Teclado](#atalhos-de-teclado)
+- [Detalhes dos Recursos](#detalhes-dos-recursos)
+  - [a: Menu Adicionar para...](#a-menu-adicionar-para)
+  - [d: Baixar Vídeo/Áudio](#d-baixar-vídeoáudio)
+  - [b: Baixar Legendas](#b-baixar-legendas)
+  - [e: Pesquisar no YouTube](#e-pesquisar-no-youtube)
+  - [i: Informações do Vídeo](#i-informações-do-vídeo)
+  - [t: Capítulos / Marcadores de Tempo](#t-capítulos--marcadores-de-tempo)
+  - [l: Comentários / Chat ao Vivo / Reprise do Chat ao Vivo](#l-comentários--chat-ao-vivo--reprise-do-chat-ao-vivo)
+  - [Favoritos (f, c, p, w)](#favoritos-f-c-p-w)
+  - [s: Feed de Inscrições](#s-feed-de-inscrições)
+  - [m: Gerenciar Inscrições](#m-gerenciar-inscrições)
+  - [u: Gerenciador de Perfis de Usuário](#u-gerenciador-de-perfis-de-usuário)
+  - [Lista de Vídeos](#lista-de-vídeos)
+- [Configurações](#configurações)
+- [Informações Adicionais](#informações-adicionais)
+
+---
+
+## Atalhos de Teclado
+
+Este complemento utiliza um sistema de **Comando em Camadas** para evitar conflitos com outros complementos ou comandos do NVDA.
+
+**Como usar:**
+
+1. Pressione **NVDA+Y** para entrar no Modo de Comando do YoutubePlus (você ouvirá um som de notificação).
+2. Pressione a letra correspondente para ativar o recurso desejado.
+
+> **Nota:** Se o atalho `NVDA+Y` conflitar com outro complemento, você pode alterá-lo em `NVDA → Preferências → Definir comandos...` sob a categoria "YoutubePlus".
+> **Detecção de URL:** Para comandos que exigem a URL de um vídeo, o complemento verifica primeiro a **janela do navegador atualmente aberta**. Se nenhuma URL do YouTube for encontrada ali, ele passa automaticamente a verificar a **área de transferência**.
+
+### Todas as teclas no modo YoutubePlus
+
+| Tecla | Recurso |
+| ----- | --------- |
+| **a** | Menu "Adicionar para..." (Favoritos / Inscrever-se) |
+| **f** | Abrir Vídeos Favoritos |
+| **c** | Abrir Canais Favoritos |
+| **p** | Abrir Playlists Favoritas |
+| **w** | Abrir Lista de Assistir Mais Tarde |
+| **b** | Baixar legendas |
+| **d** | Baixar vídeo ou áudio |
+| **e** | Pesquisar no YouTube |
+| **i** | Mostrar informações do vídeo |
+| **t** | Mostrar Capítulos / Marcadores de Tempo |
+| **m** | Gerenciar Inscrições |
+| **s** | Abrir Feed de Inscrições |
+| **u** | Gerenciar Perfis de Usuário |
+| **l** | Mostrar comentários ou iniciar monitoramento do chat ao vivo |
+| **Shift+L** | Parar monitoramento do chat ao vivo |
+| **r** | Alternar a leitura automática do chat ao vivo |
+| **v** | Reabrir a janela do chat ao vivo (enquanto a transmissão ainda estiver ativa) |
+| **y** | Abrir Configurações do YoutubePlus |
+| **h** | Abrir diálogo de Ajuda |
+
+---
+
+## Detalhes dos Recursos
+
+### a: Menu Adicionar para...
+
+Abre um submenu para escolher onde adicionar o vídeo ou canal atual:
+
+- **Adicionar aos Vídeos Favoritos** — salva o vídeo atual nos Favoritos
+- **Adicionar aos Canais Favoritos** — salva o canal do vídeo atual nos Favoritos
+- **Adicionar às Playlists Favoritas** — salva a playlist atual nos Favoritos
+- **Inscrever-se no Canal** — acompanha o canal através do sistema de Inscrições do complemento
+- **Adicionar à Lista de Assistir Mais Tarde** — salva o vídeo atual na Lista de Assistir Mais Tarde para ver depois
+
+A maioria dos comandos funciona com qualquer formato de URL do YouTube. Por exemplo, se você estiver na página de um vídeo e escolher "Adicionar aos Canais Favoritos", o complemento extrairá a URL do canal automaticamente.
+
+**Exceção:** Para Playlists, você deve estar com a página de uma playlist do YouTube aberta ou ter uma URL de playlist válida na área de transferência.
+
+---
+
+### d: Baixar Vídeo/Áudio
+
+Pressione **NVDA+Y → D** para abrir um diálogo perguntando se deseja baixar como:
+
+- **Arquivo de vídeo (MP4)** — baixa o vídeo com áudio
+- **Arquivo de áudio (M4A)** — baixa apenas o áudio
+
+Um diálogo de progresso mostra a porcentagem do download enquanto ele é executado. O botão **Cancelar** está disponível a qualquer momento.
+
+Defina a pasta de destino nas [Configurações](#configurações).
+
+> **Nota:** Este recurso é fornecido por conveniência. Para downloads em lote, recomendam-se ferramentas dedicadas.
+
+---
+
+### b: Baixar Legendas
+
+Pressione **NVDA+Y → B** para obter a lista de idiomas de legenda disponíveis para o vídeo atual e, em seguida, escolha em um diálogo. As legendas são listadas em dois tipos:
+
+- **(manual)** — legendas criadas pelo criador do vídeo ou pela comunidade
+- **(auto)** — legendas geradas automaticamente pelo YouTube
+
+Formatos de arquivo suportados: **SRT, VTT, TTML** e **TXT** (texto simples sem marcadores de tempo). Configurável nas [Configurações](#configurações).
+
+---
+
+### e: Pesquisar no YouTube
+
+Pressione **NVDA+Y → E** para abrir a janela de pesquisa. Digite sua busca e pressione Enter para pesquisar imediatamente. Pressione Tab para ajustar o número de resultados (o complemento lembra desse valor para a próxima vez).
+
+Os resultados são exibidos no mesmo formato de [Lista de Vídeos](#lista-de-vídeos) usado em todo o complemento — e não como uma página da web do YouTube. Os resultados podem incluir vídeos, canais e playlists.
+
+---
+
+### i: Informações do Vídeo
+
+Pressione **NVDA+Y → I** para visualizar os seguintes detalhes do vídeo atual:
+
+- Título
+- Canal
+- Duração
+- Data de envio
+- Contagem de visualizações
+- Contagem de curtidas
+- Contagem de comentários
+- Descrição
+
+---
+
+### t: Capítulos / Marcadores de Tempo
+
+Pressione **NVDA+Y → T** para visualizar a lista de capítulos ou marcadores de tempo do vídeo atual (se o criador incluiu essas informações). Se o complemento informar "Nenhum capítulo encontrado", o vídeo simplesmente não possui dados de capítulos.
+
+Esta janela inclui:
+
+- **Campo de pesquisa** — filtra a lista de capítulos em tempo real; não é necessário pressionar Enter
+- **Lista de capítulos** — mostra o título do capítulo e o tempo de início
+- **Área de texto** — exibe o nome do capítulo selecionado em um formato legível
+- **Botão Abrir Capítulo** (o pressione Espaço/Enter) — pula direto para aquele capítulo no navegador
+- **Botão Copiar Título** — copia o título do capítulo
+- **Botão Copiar URL** — copia a URL com o marcador de tempo para aquele capítulo
+- **Botão Exportar** — salva todos os capítulos em um arquivo de texto
+
+---
+
+### l: Comentários / Chat ao Vivo / Reprise do Chat ao Vivo
+
+O YoutubePlus suporta três tipos de conteúdo através deste comando:
+
+#### 1. Comentários (para vídeos normais)
+
+Pressione **NVDA+Y → L** enquanto estiver na página de um vídeo. O complemento obterá todos os comentários. Os comentários fixados aparecem primeiro, seguidos por todos os outros na ordem de classificação configurada nas Configurações.
+
+**A janela de Comentários inclui:**
+
+- **Campo de pesquisa** — filtra os comentários em tempo real
+- **Caixa de combinação de filtro** — filtros predefinidos:
+  - Sem Filtro — mostra todos os comentários
+  - Filtrar por Autor Selecionado — mostra apenas comentários do comentarista selecionado
+  - Mostrar Apenas Super Chats
+  - Mostrar Apenas Super Stickers
+  - Mostrar Apenas Valeu Demais
+- **Lista de comentários** — mostra o nome do comentarista e a mensagem; há suporte para tópicos de respostas
+- **Área de texto somente leitura** — mostra o texto completo do comentário selecionado, útil para comentários longos
+- **Botão Copiar** (Alt+C ou Ctrl+C) — copia o comentário selecionado
+- **Botão Exportar** (Alt+E) — salva todos os comentários em um arquivo de texto
+
+#### 2. Chat ao Vivo (para transmissões ao vivo ativas)
+
+Para vídeos que estão transmitindo ao vivo no momento, pressione L para abrir uma janela que recebe as mensagens do chat. Apenas as mensagens recebidas após a ativação deste comando são exibidas — o histórico anterior não é capturado.
+
+- Feche e reabra a janela com o comando **V**, desde que o monitoramento não tenha sido interrompido.
+- Use o comando **R** para alternar a leitura automática de novas mensagens — ideal para transmissões com mensagens pouco frequentes. Para transmissões com grande volume de mensagens, recomenda-se desativar a leitura automática e rolar manualmente pela janela.
+- Use **Shift+L** para parar o monitoramento. Quando interrompido, o complemento perguntará se você deseja salvar o histórico do chat em um arquivo.
+
+**Configurações relacionadas:**
+
+- **Falar chat ao vivo recebido automaticamente:** Lê novas mensagens em voz alta à medida que chegam (o mesmo que o comando R, mas salvo como uma preferência padrão).
+- **Intervalo de atualização do chat ao vivo:** Com que frequência (inércia em segundos) o complemento verifica se há novas mensagens (padrão: 5 segundos).
+- **Limite do histórico de mensagens:** Máximo de mensagens armazenadas na memória (padrão: 5.000). O complemento possui um limite máximo fixo de 200.000 mensagens para evitar o uso excessivo de memória.
+
+#### 3. Reprise do Chat ao Vivo (para transmissões anteriores)
+
+Para vídeos que já foram transmitidos ao vivo e onde o canal não removeu o chat, pressionar L exibirá um diálogo perguntando se deseja visualizar os **Comentários** ou a **Reprise do Chat ao Vivo**. A janela de reprise tem a mesma estrutura da janela de Comentários, com uma adição:
+
+- **Valor Pago Total** — mostra o total de doações (Super Chats / Super Stickers) arrecadadas durante a transmissão
+
+---
+
+### Favoritos (f, c, p, w)
+
+A janela de Favoritos está dividida em 4 abas, cada uma acessível por comandos separados ou todas dentro da mesma janela.
+
+| Tecla | Aba |
+| ----- | ----- |
+| **F** | Vídeos salvos (Vídeos Favoritos) |
+| **C** | Canais salvos (Canais Favoritos) |
+| **P** | Playlists salvas (Playlists Favoritas) |
+| **W** | Vídeos para assistir mais tarde (Lista de Assistir Mais Tarde) |
+
+#### Atalhos na janela de Favoritos
+
+- **Ctrl+1 a Ctrl+4** — alterna entre as abas
+- **Ctrl+Seta para cima/Seta para baixo** — reordena as abas
+- **Ctrl+C / Ctrl+X / Ctrl+V** — copia/recorta/cola para mover itens
+  _(Vídeos Favoritos ↔ Lista de Assistir Mais Tarde podem ser movidos entre si; Canais e Playlists só podem ser movidos dentro de sua própria lista)_
+- **F2** — renomeia manualmente o vídeo/canal/playlist selecionado
+- **Alt+R ou Delete** — remove o item selecionado
+- **Alt+N** — adiciona um novo item a partir de uma URL na área de transferência
+- **Alt+S** — move o foco para o campo de pesquisa (os resultados são atualizados em tempo real)
+- **Botão Ordenar... (Alt+O)** — ordena a lista:
+  - Ordenar por: Título, Canal, Duração, Data de Adição ou Data de Envio
+  - Escolha Crescente ou Decrescente
+  - Se "Aplicar permanentemente" estiver marcado, a ordem é salva; caso contrário, ela é redefinida ao pesquisar ou atualizar
+  - Pressione "Limpar Ordenação" para restaurar a ordem original
+
+#### Aba Canais (Favoritos)
+
+Esta aba oferece mais do que uma simples lista — ela também inclui:
+
+- **Área de texto da descrição do canal** — mostra a biografia/informações sobre o canal
+- **Botão Abrir canal no navegador**
+- **Botões para navegar pelos conteúdos de Vídeos / Shorts / Ao Vivo** daquele canal diretamente
+
+#### Aba Playlists (Favoritos)
+
+- Pressione **Espaço, Enter ou Alt+V** — expande todos os vídeos da playlist
+- **Botão Abrir na Web (Alt+W)** — abre a playlist no navegador
+
+---
+
+### s: Feed de Inscrições
+
+Uma janela que exibe vídeos dos canais que você acompanha através do complemento. Isso é **independente** das inscrições da sua conta do YouTube — não é necessário fazer login.
+
+A visualização padrão possui 4 abas por tipo de conteúdo:
+
+| Aba | Conteúdo |
+| ----- | --------- |
+| **Tudo** | Todos os tipos de conteúdo combinados |
+| **Vídeo** | Apenas vídeos normais |
+| **Shorts** | Apenas vídeos de formato curto (Shorts) |
+| **Ao Vivo** | Transmissões ao vivo e reprises de lives |
+
+Você também pode criar **categorias personalizadas** e configurar quais canais aparecem em cada uma delas.
+
+#### Atalhos no Feed de Inscrições
+
+- **Ctrl+1 a Ctrl+0** — pula para uma aba de categoria (até 10 abas)
+- **Ctrl+Seta para cima/Seta para baixo** — reordena as abas/categorias
+- **F2** — renomeia uma categoria (exceto as 4 abas padrão)
+- **Ctrl+= (Igual)** — adiciona uma nova categoria
+- **Ctrl+- (Ífen)** — remove uma categoria (exceto as 4 abas padrão)
+- **Delete ou Alt+S** — marca um vídeo como visto; ele será removido da lista
+- **Ctrl+Delete** — marca todos os vídeos da aba atual como vistos
+
+#### Botões na janela do Feed de Inscrições
+
+- **Marcar como visto (Alt+S)** — marca o vídeo selecionado como visto
+- **Adicionar nova Inscrição a partir da URL da área de transferência (Alt+N)** — inscreve-se em um canal usando a URL que estiver na área de transferência
+- **Atualizar Feed (Alt+U)** — aciona manualmente uma atualização de todos os canais inscritos (o complemento também se atualiza automaticamente ao iniciar o NVDA)
+- **Mais... (Alt+M)** — opções adicionais:
+  - Marcar todos na aba atual como vistos (Ctrl+Delete)
+  - Mostrar todos os vídeos (incluindo vistos) — alterna entre apenas não vistos e todos os vídeos; a configuração é salva automaticamente
+  - Gerenciar inscrições...
+  - Adicionar Nova Categoria... (Ctrl+=)
+  - Renomear Categoria Atual... (F2)
+  - Remover Categoria Atual... (Ctrl+-)
+  - **Limpar Todos os Vídeos do Feed...** — remove todos os vídeos do banco de dados sem remover os canais inscritos; útil quando o banco de dados cresce muito e afeta o desempenho do NVDA
+
+---
+
+### m: Gerenciar Inscrições
+
+Uma janela que mostra todos os canais nos quais você está inscrito, com opções de gerenciamento para cada um:
+
+- **Filtrar por Categoria** — filtra a lista de canais por categoria (padrão: Tudo)
+- **Atribuir a Categorias** — escolhe em quais categorias o conteúdo deste canal deve aparecer
+- **Tipos de Conteúdo a Obter** — escolhe quais tipos de conteúdo atualizar para este canal (Vídeos, Shorts, Ao Vivo); útil para canais que publicam apenas certos tipos
+- **Visualizar Conteúdo... (Alt+C)** — navega pelo conteúdo do canal (o mesmo que o botão Ação)
+- **Adicionar novo canal de inscrição a partir da Área de Transferência... (Alt+N)** — inscreve-se em um novo canal usando a URL que estiver na área de transferência
+- **Cancelar Inscrição deste Canal (Alt+U)** — remove o canal das suas inscrições
+- **Salvar Alterações** — ⚠️ **Importante:** você deve pressionar este botão antes de fechar a janela, caso contrário, suas alterações não serão salvas
+
+---
+
+### u: Gerenciador de Perfis de Usuário
+
+O complemento suporta múltiplos **Perfis de Usuário** na mesma máquina. Cada perfil mantém seus dados completamente separados (Favoritos, Inscrições, Lista de Assistir Mais Tarde).
+
+Nesta janela:
+
+- **F2** — renomeia o perfil selecionado
+- **Delete** — exclui o perfil selecionado ⚠️ A exclusão é permanente; todos os dados daquele perfil serão perdidos
+
+Para alternar de perfil, vá em [Configurações](#configurações) → Perfil Ativo e, em seguida, reinicie o NVDA.
+
+---
+
+### Lista de Vídeos
+
+A lista de vídeos é a interface padrão usada em todo o complemento — nos resultados de pesquisa, Favoritos, Feed de Inscrições e na navegação de vídeos de canais.
+
+- Pressione **Enter** para abrir o vídeo no navegador
+- Pressione **Espaço** para realizar a Ação Rápida (configurável nas Configurações)
+
+#### Botão Ação (Alt+A)
+
+Abre o menu de Ações para o vídeo selecionado:
+
+| Item do menu | Atalho |
+| ----------- | --------- |
+| Ver Informações do Vídeo | i |
+| Ver Comentários / Reprise | c |
+| Ver Capítulos/Marcadores de Tempo | t |
+| Baixar Vídeo | d |
+| Baixar Áudio | a |
+| Baixar Legendas | b |
+| Adicionar aos Vídeos Favoritos | f |
+| Adicionar aos Canais Favoritos | f |
+| Adicionar à Lista de Assistir Mais Tarde | w |
+| Abrir vídeo no navegador | o |
+| Abrir canal no navegador | h |
+| Mostrar vídeos do canal | v |
+| Mostrar shorts do canal | s |
+| Mostrar lives do canal | l |
+
+#### Botão Copiar (Alt+C)
+
+Abre o menu de Cópia:
+
+| Item do menu | Atalho |
+| ----------- | --------- |
+| Copiar Título | t |
+| Copiar URL do Vídeo | u |
+| Copiar Nome do Canal | c |
+| Copiar URL do Canal | h |
+| Copiar Resumo | s |
+
+---
+
+## Configurações
+
+Acesse através de `NVDA → Preferências → Configurações...` e selecione a categoria **"YoutubePlus"**.
+
+| Configuração | Descrição |
+| --------- | ------------- |
+| **Perfil Ativo** | Seleciona o perfil ativo (requer a reinicialização do NVDA após a alteração) |
+| **Gerenciar Perfis** | Abre o Gerenciador de Perfis de Usuário |
+| **Ação Rápida (Barra de espaço)** | Define o que a tecla Espaço faz nas janelas de lista de vídeos; todas as opções do menu de Ação estão disponíveis |
+| **Modo de notificação** | Como o complemento sinaliza atividades em segundo plano: **Bip** (tons curtos), **Som** (arquivo de áudio), **Silencioso** (sem áudio, mensagens faladas ainda ocorrem) |
+| **Ordem de classificação padrão** | Ordem de exibição padrão: **Mais recentes primeiro** ou **Mais antigos primeiro** — aplica-se a comentários, chat e listas de vídeos de canais |
+| **Itens a obter** | Número de itens recuperados por tipo de conteúdo ao navegar em um canal ou atualizar o feed (padrão: 20, intervalo: 5–100) |
+| **Tipos de conteúdo padrão** | Tipos de conteúdo a obter para canais recém-inscritos: Vídeos, Shorts, Ao Vivo |
+| **Intervalo de atualização em segundo plano** | Com que frequência o complemento verifica automaticamente se há novos conteúdos nos canais inscritos (desativado, ou de 15 minutos a 24 horas) |
+| **Falar chat ao vivo recebido automaticamente** | Lê novas mensagens do chat ao vivo em voz alta à medida que chegam |
+| **Intervalo de atualização do chat ao vivo** | Com que frequência (em segundos) o complemento verifica se há novas mensagens (padrão: 5 segundos) |
+| **Limite do histórico de mensagens** | Número máximo de mensagens de chat armazenadas na memória durante uma sessão (padrão: 5.000) |
+| **Método de Cookies (Experimental)** | Selecione o navegador no qual você está logado no YouTube. O complemento extrairá os cookies desse navegador para autenticar as requisições, o que pode ajudar a resolver o erro "Faça login para confirmar que você não é um robô". Note que este recurso é experimental e os resultados variam dependendo do navegador e da configuração do sistema. |
+| **Formato de legenda padrão** | Formato de arquivo de legenda para downloads: SRT, VTT, TTML ou TXT (texto simples sem marcadores de tempo) |
+| **Caminho padrão da pasta de download e exportação** | Pasta de destino para vídeos baixados, áudios e arquivos exportados |
+| **Fazer backup dos dados agora** | Faz o backup imediato de todos os dados do perfil ativo (o complemento também realiza um backup automático diário) |
+| **Restaurar dados a partir do backup** | Mostra os backups disponíveis (até os últimos 5 dias) para escolher para a restauração |
+
+---
+
+## Informações Adicionais
+
+Este complemento conta com duas bibliotecas principais: [pytchat](https://pypi.org/project/pytchat/) para o monitoramento do chat ao vivo, e [yt-dlp](https://pypi.org/project/yt-dlp/) para todos os outros acessos a dados do YouTube. Expressamos nossos sinceros agradecimentos aos desenvolvedores de ambas as bibliotecas.
+
+### Sobre o yt-dlp
+
+O [yt-dlp](https://github.com/yt-dlp/yt-dlp) é uma das ferramentas de código aberto mais poderosas para baixar vídeos e áudios de sites em todo o mundo — suportando mais de 1.000 sites, não apenas o YouTube. Ele é gratuito, de código aberto, mantido ativamente por uma comunidade global e não contém anúncios ou malwares, ao contrário de muitas ferramentas de download baseadas no navegador.
+
+**Diretrizes de uso para ter em mente:**
+
+1. **Uso Justo:** Evite obter grandes quantidades de dados ou enviar requisições repetidas em um curto espaço de tempo. O YouTube pode detectar atividade incomum e restringir temporariamente o acesso do seu endereço IP.
+2. **Direitos Autorais e Privacidade:** Quaisquer dados ou conteúdos recuperados devem ser apenas para visualização ou análise pessoal. Por favor, respeite os Termos de Serviço de cada plataforma e não utilize os dados de maneiras que infrinjam os direitos autorais.
+3. **Responsabilidade:** Você é responsável por como utiliza este software. O desenvolvedor do complemento fornece apenas a interface para acessar os dados do YouTube através da biblioteca yt-dlp.
+
+> **Dica:** Se você precisar processar grandes quantidades de dados, espaçe suas requisições para manter a estabilidade da conexão e evitar restrições de acesso.

--- a/addon/locale/pt_BR/LC_MESSAGES/nvda.po
+++ b/addon/locale/pt_BR/LC_MESSAGES/nvda.po
@@ -1,0 +1,2559 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: YoutubePlus 2026.6.13\n"
+"Report-Msgid-Bugs-To: NVDA_TH <nvdainth@gmail.com>, assisted by A.I.\n"
+"POT-Creation-Date: 2026-06-15 14:05-0300\n"
+"PO-Revision-Date: 2026-06-15 14:38-0300\n"
+"Last-Translator: Edilberto Fonseca <edilberto.fonseca@outlook.com>\n"
+"Language-Team: Edilberto Fonseca <edilberto.fonseca@outlook.com>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.8\n"
+"X-Poedit-Basepath: ../../..\n"
+"X-Poedit-SearchPath-0: globalPlugins/YoutubePlus\n"
+"X-Poedit-SearchPath-1: buildVars.py\n"
+
+#: buildVars.py:23
+msgid "YouTubePlus"
+msgstr "YouTube Plus"
+
+#: buildVars.py:27
+msgid ""
+"YoutubePlus is an add-on for those who enjoy YouTube but find many web "
+"features difficult to access, such as reading video comments.\n"
+"We bring these features to you through the NVDA user interface in an "
+"accessible, shortcut-driven, and customizable format.\n"
+"Users do not need to deal with API keys or link any personal data to the add-"
+"on.\n"
+"\n"
+"features:       \n"
+"â€¢ You can follow your favorite channels and be certain that you will see "
+"every video they post without being filtered out by YouTube's algorithm.\n"
+"â€¢ we offer a Favorites system for videos, channels, playlists, and a Watch "
+"List for saving videos you're interested in but don't have time to watch "
+"yet.\n"
+"â€¢ built-in search system that displays results within the same accessible "
+"UI as other features, rather than just providing a search box that opens the "
+"web results.\n"
+"â€¢ included download feature for saving videos or audio files."
+msgstr ""
+"O YoutubePlus é um complemento para quem gosta do YouTube, mas acha difícil "
+"acessar muitos recursos da Web, como a leitura de comentários de vídeos.\n"
+"Trazemos esses recursos para você através da interface de usuário do NVDA em "
+"um formato acessível, baseado em atalhos e personalizável.\n"
+"Os usuários não precisam lidar com chaves de API nem vincular dados pessoais "
+"ao complemento.\n"
+"\n"
+"recursos: \n"
+"â€¢ Você pode seguir seus canais favoritos e ter certeza de que verá todos "
+"os vídeos postados por eles sem ser filtrado pelo algoritmo do YouTube.\n"
+"â€¢ oferecemos um sistema de favoritos para vÃdeos, canais, playlists e uma "
+"lista de observaÃ§Ã£o para salvar vÃdeos de seu interesse, mas que ainda "
+"nÃ£o tem tempo para assistir.\n"
+"â€¢ sistema de pesquisa integrado que exibe resultados na mesma IU acessÃvel "
+"de outros recursos, em vez de apenas fornecer uma caixa de pesquisa que abre "
+"os resultados da Web.\n"
+"â€¢ incluÃdo recurso de download para salvar vÃdeos ou arquivos de Ã¡udio."
+
+#: globalPlugins/YoutubePlus/core.py:462
+#, python-brace-format
+msgid "Failed to get video data. Details: {}"
+msgstr "Falha ao obter dados do vídeo. Detalhes: {}"
+
+#: globalPlugins/YoutubePlus/core.py:466
+msgid "An unexpected error occurred."
+msgstr "Ocorreu um erro inesperado."
+
+#: globalPlugins/YoutubePlus/core.py:479
+msgid "This command is for videos, but the current page is a playlist."
+msgstr "Este comando é para vídeos, mas a página atual é uma playlist."
+
+#: globalPlugins/YoutubePlus/core.py:486
+msgid ""
+"This command is for videos, but the current page appears to be a channel or "
+"playlist."
+msgstr ""
+"Este comando é para vídeos, mas a página atual parece ser um canal ou "
+"playlist."
+
+#: globalPlugins/YoutubePlus/core.py:740
+msgid "activate YoutubePlus"
+msgstr "ativar o YoutubePlus"
+
+#: globalPlugins/YoutubePlus/core.py:839
+#, python-brace-format
+msgid "Super Chat ({amount}): {paid_message}"
+msgstr "Super Chat ({amount}): {paid_message}"
+
+#: globalPlugins/YoutubePlus/core.py:853
+#, python-brace-format
+msgid "Super Sticker ({amount})"
+msgstr "Super Sticker ({amount})"
+
+#: globalPlugins/YoutubePlus/core.py:884
+#, python-brace-format
+msgid "YouTube System ({icon_type})"
+msgstr "Sistema do YouTube ({icon_type})"
+
+#: globalPlugins/YoutubePlus/core.py:906
+#, python-brace-format
+msgid "{h} Hour"
+msgstr "{h} hora"
+
+#: globalPlugins/YoutubePlus/core.py:908
+#, python-brace-format
+msgid "{h} Hours"
+msgstr "{h} horas"
+
+#: globalPlugins/YoutubePlus/core.py:913
+#, python-brace-format
+msgid "{m} Minute"
+msgstr "{m} minuto"
+
+#: globalPlugins/YoutubePlus/core.py:913
+#, python-brace-format
+msgid "{m} Minutes"
+msgstr "{m} minutos"
+
+#: globalPlugins/YoutubePlus/core.py:916
+#, python-brace-format
+msgid "{s} Second"
+msgstr "{s} segundo"
+
+#: globalPlugins/YoutubePlus/core.py:916
+#, python-brace-format
+msgid "{s} Seconds"
+msgstr "{s} segundos"
+
+#: globalPlugins/YoutubePlus/core.py:951
+#, python-brace-format
+msgid "Info of {title}"
+msgstr "Informações de {title}"
+
+#: globalPlugins/YoutubePlus/core.py:968
+msgid "This video has a live chat replay. What would you like to view?"
+msgstr ""
+"Este vídeo possui um replay do chat ao vivo. O que você gostaria de ver?"
+
+#: globalPlugins/YoutubePlus/core.py:968
+msgid "Choice"
+msgstr "Escolha"
+
+#: globalPlugins/YoutubePlus/core.py:972
+#, python-brace-format
+msgid "Show {comment_count} &Comments"
+msgstr "Exibir {comment_count} &Comentários"
+
+#: globalPlugins/YoutubePlus/core.py:972
+msgid "Show &Live Chat Replay"
+msgstr "Exibir Replay do Chat ao &Vivo"
+
+#: globalPlugins/YoutubePlus/core.py:972 globalPlugins/YoutubePlus/core.py:1857
+#: globalPlugins/YoutubePlus/dialogs.py:3012
+msgid "Ca&ncel"
+msgstr "Ca&ncelar"
+
+#: globalPlugins/YoutubePlus/core.py:1011
+msgid "This video has no comments."
+msgstr "Este vídeo não tem comentários."
+
+#: globalPlugins/YoutubePlus/core.py:1015
+#, python-brace-format
+msgid "Loading {count} comments..."
+msgstr "Carregando {count} comentários..."
+
+#: globalPlugins/YoutubePlus/core.py:1018
+msgid "Loading live chat replay..."
+msgstr "Carregando replay do chat ao vivo..."
+
+#: globalPlugins/YoutubePlus/core.py:1032
+msgid ""
+"Live stream detected. Please use the 'Monitor live chat' command instead."
+msgstr ""
+"Transmissão ao vivo detectada. Por favor, use o comando 'Monitorar chat ao "
+"vivo'."
+
+#: globalPlugins/YoutubePlus/core.py:1048
+#, python-brace-format
+msgid "Title: {title}"
+msgstr "Título: {title}"
+
+#: globalPlugins/YoutubePlus/core.py:1049
+#, python-brace-format
+msgid "Channel: {uploader}"
+msgstr "Canal: {uploader}"
+
+#: globalPlugins/YoutubePlus/core.py:1050
+#, python-brace-format
+msgid "Duration: {duration}"
+msgstr "Duração: {duration}"
+
+#: globalPlugins/YoutubePlus/core.py:1051
+#, python-brace-format
+msgid "Uploaded: {upload_date}"
+msgstr "Enviado em: {upload_date}"
+
+#: globalPlugins/YoutubePlus/core.py:1052
+#, python-brace-format
+msgid "Views: {view_count}"
+msgstr "Visualizações: {view_count}"
+
+#: globalPlugins/YoutubePlus/core.py:1053
+#, python-brace-format
+msgid "Likes: {like_count}"
+msgstr "Curtidas: {like_count}"
+
+#: globalPlugins/YoutubePlus/core.py:1054
+#, python-brace-format
+msgid "Comments: {comment_count}"
+msgstr "Comentários: {comment_count}"
+
+#: globalPlugins/YoutubePlus/core.py:1056
+#, python-brace-format
+msgid ""
+"Description:\n"
+"{description}"
+msgstr ""
+"Descrição:\n"
+"{description}"
+
+#: globalPlugins/YoutubePlus/core.py:1068
+#, python-brace-format
+msgid "Could not get video info: {error}"
+msgstr "Não foi possível obter as informações do vídeo: {error}"
+
+#: globalPlugins/YoutubePlus/core.py:1072
+#: globalPlugins/YoutubePlus/core.py:1100
+#: globalPlugins/YoutubePlus/core.py:1148
+msgid "An unexpected error occurred. Please check the log for details."
+msgstr ""
+"Ocorreu um erro inesperado. Por favor, verifique o registro (log) para "
+"detalhes."
+
+#: globalPlugins/YoutubePlus/core.py:1089
+#, python-brace-format
+msgid "Chapters for {title}"
+msgstr "Capítulos de {title}"
+
+#: globalPlugins/YoutubePlus/core.py:1093
+msgid "No chapters found in this video."
+msgstr "Nenhum capítulo encontrado neste vídeo."
+
+#: globalPlugins/YoutubePlus/core.py:1096
+#, python-brace-format
+msgid "Failed to get chapters. Details: {}"
+msgstr "Falha ao obter os capítulos. Detalhes: {}"
+
+#: globalPlugins/YoutubePlus/core.py:1118
+#, python-brace-format
+msgid "{count} comments of {title}"
+msgstr "{count} comentários de {title}"
+
+#: globalPlugins/YoutubePlus/core.py:1135
+#, python-brace-format
+msgid "{count} live chat replay of {title}"
+msgstr "{count} mensagens do replay do chat ao vivo de {title}"
+
+#: globalPlugins/YoutubePlus/core.py:1143
+#, python-brace-format
+msgid "Could not load data: {error}"
+msgstr "Não foi possível carregar os dados: {error}"
+
+#: globalPlugins/YoutubePlus/core.py:1160
+msgid "Connection to live chat lost. The stream may have ended."
+msgstr "Conexão com o chat ao vivo perdida. A transmissão pode ter terminado."
+
+#: globalPlugins/YoutubePlus/core.py:1186
+msgid "To conserve memory, older chat messages have been discarded."
+msgstr ""
+"Para conservar memória, as mensagens mais antigas do chat foram descartadas."
+
+#: globalPlugins/YoutubePlus/core.py:1194
+#, python-brace-format
+msgid "Receiving live chat of {video_title}"
+msgstr "Recebendo chat ao vivo de {video_title}"
+
+#: globalPlugins/YoutubePlus/core.py:1204
+msgid "An error occurred while receiving live chat. Monitoring stopped."
+msgstr ""
+"Ocorreu um erro ao receber o chat ao vivo. O monitoramento foi interrompido."
+
+#: globalPlugins/YoutubePlus/core.py:1235
+#, python-brace-format
+msgid "Live chat saved to {filename}"
+msgstr "Chat ao vivo salvo em {filename}"
+
+#: globalPlugins/YoutubePlus/core.py:1241
+msgid "Failed to save chat history."
+msgstr "Falha ao salvar o histórico do chat."
+
+#: globalPlugins/YoutubePlus/core.py:1260
+#, python-brace-format
+msgid ""
+"The stream has ended. You have {count} chat messages.\n"
+"\n"
+"Would you like to save the chat history?"
+msgstr ""
+"A transmissão terminou. Você tem {count} mensagens de chat.\n"
+"\n"
+"Gostaria de salvar o histórico do chat?"
+
+#: globalPlugins/YoutubePlus/core.py:1261
+msgid "Save Chat History?"
+msgstr "Salvar Histórico do Chat?"
+
+#: globalPlugins/YoutubePlus/core.py:1282
+#: globalPlugins/YoutubePlus/core.py:2092
+#, python-brace-format
+msgid "Could not receive live chat: {error}"
+msgstr "Não foi possível receber o chat ao vivo: {error}"
+
+#: globalPlugins/YoutubePlus/core.py:1300
+msgid "Adding to favorites..."
+msgstr "Adicionando aos favoritos..."
+
+#: globalPlugins/YoutubePlus/core.py:1307
+msgid "The provided link is not for a single video."
+msgstr "O link fornecido não é de um vídeo individual."
+
+#: globalPlugins/YoutubePlus/core.py:1315
+msgid "This video is already in your favorites."
+msgstr "Este vídeo já está nos seus favoritos."
+
+#: globalPlugins/YoutubePlus/core.py:1331
+#, python-brace-format
+msgid "Added '{title}' to favorites."
+msgstr "'{title}' foi adicionado aos favoritos."
+
+#: globalPlugins/YoutubePlus/core.py:1334
+#, python-brace-format
+msgid "Failed to add favorite. Details: {}"
+msgstr "Falha ao adicionar aos favoritos. Detalhes: {}"
+
+#: globalPlugins/YoutubePlus/core.py:1345
+msgid "Adding to favorite channels..."
+msgstr "Adicionando aos canais favoritos..."
+
+#: globalPlugins/YoutubePlus/core.py:1366
+msgid "This channel is already in your favorites."
+msgstr "Este canal já está nos seus favoritos."
+
+#: globalPlugins/YoutubePlus/core.py:1380
+#, python-brace-format
+msgid "Added '{channel}' to favorites."
+msgstr "'{channel}' foi adicionado aos favoritos."
+
+#: globalPlugins/YoutubePlus/core.py:1383
+msgid "Failed to add favorite."
+msgstr "Falha ao adicionar aos favoritos."
+
+#: globalPlugins/YoutubePlus/core.py:1391
+msgid "Adding playlist to favorites..."
+msgstr "Adicionando playlist aos favoritos..."
+
+#: globalPlugins/YoutubePlus/core.py:1409
+msgid "This playlist is already in your favorites."
+msgstr "Esta playlist já está nos seus favoritos."
+
+#: globalPlugins/YoutubePlus/core.py:1413
+msgid "Unknown Playlist"
+msgstr "Playlist desconhecida"
+
+#: globalPlugins/YoutubePlus/core.py:1427
+#, python-brace-format
+msgid "Added '{playlist}' to favorites."
+msgstr "'{playlist}' foi adicionada aos favoritos."
+
+#: globalPlugins/YoutubePlus/core.py:1430
+msgid "Failed to add favorite playlist."
+msgstr "Falha ao adicionar a playlist favorita."
+
+#: globalPlugins/YoutubePlus/core.py:1473
+#, python-brace-format
+msgid "'{title}' is already in Watch List."
+msgstr "'{title}' já está na Lista de Reprodução."
+
+#: globalPlugins/YoutubePlus/core.py:1487
+#, python-brace-format
+msgid "Added '{title}' to Watch List."
+msgstr "'{title}' foi adicionado à Lista de Reprodução."
+
+#: globalPlugins/YoutubePlus/core.py:1495
+#, python-brace-format
+msgid "Error: Could not add video to Watch List. Details: {}"
+msgstr ""
+"Erro: Não foi possível adicionar o vídeo à Lista de Reprodução. Detalhes: {}"
+
+#: globalPlugins/YoutubePlus/core.py:1542
+#: globalPlugins/YoutubePlus/core.py:1552
+msgid "[Unavailable video]"
+msgstr "[Vídeo indisponível]"
+
+#: globalPlugins/YoutubePlus/core.py:1563
+msgid "No videos found."
+msgstr "Nenhum vídeo encontrado."
+
+#: globalPlugins/YoutubePlus/core.py:1570
+#, python-brace-format
+msgid "{count} videos in {playlist}"
+msgstr "{count} vídeos em {playlist}"
+
+#: globalPlugins/YoutubePlus/core.py:1570
+msgid "Playlist"
+msgstr "Playlist"
+
+#: globalPlugins/YoutubePlus/core.py:1575
+#, python-brace-format
+#| msgid "Recent {count} {type} from {channel}"
+msgid "All {count} {type} from {channel}"
+msgstr "Todos os {count} {type} de {channel}"
+
+#: globalPlugins/YoutubePlus/core.py:1575
+#: globalPlugins/YoutubePlus/core.py:1577
+#: globalPlugins/YoutubePlus/core.py:2041
+#: globalPlugins/YoutubePlus/dialogs.py:1266
+#: globalPlugins/YoutubePlus/dialogs.py:1392
+#: globalPlugins/YoutubePlus/dialogs.py:1944
+#: globalPlugins/YoutubePlus/dialogs.py:2237
+#: globalPlugins/YoutubePlus/dialogs.py:2396
+#: globalPlugins/YoutubePlus/dialogs.py:2665
+msgid "Channel"
+msgstr "Canal"
+
+#: globalPlugins/YoutubePlus/core.py:1577
+#, python-brace-format
+msgid "Recent {count} {type} from {channel}"
+msgstr "{count} {type} recentes de {channel}"
+
+#: globalPlugins/YoutubePlus/core.py:1599
+msgid "Failed to fetch video list."
+msgstr "Falha ao buscar a lista de vídeos."
+
+#: globalPlugins/YoutubePlus/core.py:1607
+msgid "Subscribing to channel..."
+msgstr "Inscrevendo-se no canal..."
+
+#: globalPlugins/YoutubePlus/core.py:1636
+#, python-brace-format
+msgid ""
+"You are already subscribed to '{channel}'.\n"
+"Would you like to unsubscribe instead?"
+msgstr ""
+"Você já está inscrito em '{channel}'.\n"
+"Gostaria de cancelar a inscrição?"
+
+#: globalPlugins/YoutubePlus/core.py:1638
+msgid "Already Subscribed"
+msgstr "Já Inscrito"
+
+#: globalPlugins/YoutubePlus/core.py:1659
+msgid "Unknown Channel"
+msgstr "Canal desconhecido"
+
+#: globalPlugins/YoutubePlus/core.py:1674
+#, python-brace-format
+msgid "Subscribed to {channel}."
+msgstr "Inscrito em {channel}."
+
+#: globalPlugins/YoutubePlus/core.py:1677
+msgid "Failed to subscribe."
+msgstr "Falha ao se inscrever."
+
+#: globalPlugins/YoutubePlus/core.py:1697
+#, python-brace-format
+msgid "Successfully unsubscribed from {channel}"
+msgstr "Inscrição cancelada com sucesso de {channel}"
+
+#: globalPlugins/YoutubePlus/core.py:1700
+msgid "Failed to unsubscribe - channel not found in database"
+msgstr "Falha ao cancelar inscrição - canal não encontrado no banco de dados"
+
+#: globalPlugins/YoutubePlus/core.py:1704
+msgid "Critical error during unsubscribe."
+msgstr "Erro crítico ao cancelar inscrição."
+
+#: globalPlugins/YoutubePlus/core.py:1726
+#: globalPlugins/YoutubePlus/core.py:1729
+msgid "No channels to update."
+msgstr "Nenhum canal para atualizar."
+
+#: globalPlugins/YoutubePlus/core.py:1746
+#, python-brace-format
+msgid "Checking {channel} ({type})..."
+msgstr "Verificando {channel} ({type})..."
+
+#: globalPlugins/YoutubePlus/core.py:1774
+#: globalPlugins/YoutubePlus/core.py:1777
+#: globalPlugins/YoutubePlus/dialogs.py:4164
+msgid "Update cancelled."
+msgstr "Atualização cancelada."
+
+#: globalPlugins/YoutubePlus/core.py:1780
+#, python-brace-format
+msgid "Update complete. Found {count} new videos."
+msgstr "Atualização concluída. Foram encontrados {count} novos vídeos."
+
+#: globalPlugins/YoutubePlus/core.py:1787
+#, python-brace-format
+msgid "Found and added {count} new videos."
+msgstr "Foram encontrados e adicionados {count} novos vídeos."
+
+#: globalPlugins/YoutubePlus/core.py:1790
+msgid "No new videos found."
+msgstr "Nenhum vídeo novo encontrado."
+
+#: globalPlugins/YoutubePlus/core.py:1796
+msgid "Error updating feed."
+msgstr "Erro ao atualizar o feed."
+
+#: globalPlugins/YoutubePlus/core.py:1814
+#: globalPlugins/YoutubePlus/core.py:1833
+#: globalPlugins/YoutubePlus/core.py:2438
+msgid "Unknown Video"
+msgstr "Vídeo desconhecido"
+
+#: globalPlugins/YoutubePlus/core.py:1820
+#, python-brace-format
+msgid "Failed to get video info for download. Details: {}"
+msgstr "Falha ao obter informações do vídeo para download. Detalhes: {}"
+
+#: globalPlugins/YoutubePlus/core.py:1827
+#: globalPlugins/YoutubePlus/core.py:2258
+msgid "Getting video info for download..."
+msgstr "Obtendo informações do vídeo para download..."
+
+#: globalPlugins/YoutubePlus/core.py:1843
+#, python-brace-format
+msgid "Failed to start download: {error}"
+msgstr "Falha ao iniciar o download: {error}"
+
+#: globalPlugins/YoutubePlus/core.py:1851
+msgid "What would you like to download?"
+msgstr "O que você gostaria de baixar?"
+
+#: globalPlugins/YoutubePlus/core.py:1853
+#, python-brace-format
+msgid "Download: {title} ({duration})"
+msgstr "Baixar: {title} ({duration})"
+
+#: globalPlugins/YoutubePlus/core.py:1857
+msgid "Download &Video"
+msgstr "Baixar &Vídeo"
+
+#: globalPlugins/YoutubePlus/core.py:1857
+#: globalPlugins/YoutubePlus/dialogs.py:911
+msgid "Download &Audio"
+msgstr "Baixar á&Udio"
+
+#: globalPlugins/YoutubePlus/core.py:1946
+#, python-brace-format
+msgid "Starting download of {title}..."
+msgstr "Iniciando o download de {title}..."
+
+#: globalPlugins/YoutubePlus/core.py:1968
+#, python-brace-format
+msgid "Download complete: {title}"
+msgstr "Download concluído: {title}"
+
+#: globalPlugins/YoutubePlus/core.py:1973
+msgid "Download cancelled."
+msgstr "Download cancelado."
+
+#: globalPlugins/YoutubePlus/core.py:1978
+msgid ""
+"Audio-only format not found. Attempting to download a video file with audio "
+"instead..."
+msgstr ""
+"Formato somente de áudio não encontrado. Tentando baixar um arquivo de vídeo "
+"com áudio em vez disso..."
+
+#: globalPlugins/YoutubePlus/core.py:1986
+#, python-brace-format
+msgid "Download complete (as MP4 video file): {title}"
+msgstr "Download concluído (como arquivo de vídeo MP4): {title}"
+
+#: globalPlugins/YoutubePlus/core.py:1992
+#: globalPlugins/YoutubePlus/core.py:1996
+msgid "Download failed."
+msgstr "Falha no download."
+
+#: globalPlugins/YoutubePlus/core.py:2018
+#, python-brace-format
+msgid "Searching for '{query}'..."
+msgstr "Pesquisando por '{query}'..."
+
+#: globalPlugins/YoutubePlus/core.py:2033
+#: globalPlugins/YoutubePlus/dialogs.py:1994
+#: globalPlugins/YoutubePlus/dialogs.py:2049
+#: globalPlugins/YoutubePlus/dialogs.py:2623
+#: globalPlugins/YoutubePlus/dialogs.py:3146
+#: globalPlugins/YoutubePlus/dialogs.py:3245
+#: globalPlugins/YoutubePlus/dialogs.py:3973
+msgid "N/A"
+msgstr "N/D"
+
+#: globalPlugins/YoutubePlus/core.py:2044
+#, python-brace-format
+msgid "Playlist ({count})"
+msgstr "Playlist ({count})"
+
+#: globalPlugins/YoutubePlus/core.py:2048
+#, python-brace-format
+msgid "No results found for '{query}'."
+msgstr "Nenhum resultado encontrado para '{query}'."
+
+#: globalPlugins/YoutubePlus/core.py:2051
+#, python-brace-format
+msgid "Search Results for '{query}'"
+msgstr "Resultados da Pesquisa por '{query}'"
+
+#: globalPlugins/YoutubePlus/core.py:2056
+msgid "Failed to perform search."
+msgstr "Falha ao realizar a pesquisa."
+
+#: globalPlugins/YoutubePlus/core.py:2066
+#, python-brace-format
+msgid "Live chat of {title}"
+msgstr "Chat ao vivo de {title}"
+
+#: globalPlugins/YoutubePlus/core.py:2066
+msgid "Live chat (stopped)"
+msgstr "Chat ao vivo (interrompido)"
+
+#: globalPlugins/YoutubePlus/core.py:2099
+msgid "Chat monitoring is not active."
+msgstr "O monitoramento do chat não está ativo."
+
+#: globalPlugins/YoutubePlus/core.py:2109
+msgid "Chat monitoring stopped."
+msgstr "Monitoramento do chat interrompido."
+
+#: globalPlugins/YoutubePlus/core.py:2121
+#, python-brace-format
+msgid "Live chat of {title} (stopped)"
+msgstr "Chat ao vivo de {title} (interrompido)"
+
+#: globalPlugins/YoutubePlus/core.py:2141
+msgid "You haven't subscribed to any channels yet."
+msgstr "Você ainda não se inscreveu em nenhum canal."
+
+#: globalPlugins/YoutubePlus/core.py:2151
+msgid "Error loading subscription feed from database."
+msgstr "Erro ao carregar o feed de inscrições do banco de dados."
+
+#: globalPlugins/YoutubePlus/core.py:2166
+msgid ""
+"This will permanently delete ALL videos from your subscription feed, leaving "
+"only the list of subscribed channels. This action cannot be undone.\n"
+"\n"
+"Are you sure you want to continue?"
+msgstr ""
+"Isso apagará permanentemente TODOS os vídeos do seu feed de inscrições, "
+"mantendo apenas a lista de canais inscritos. Esta ação não pode ser "
+"desfeita.\n"
+"\n"
+"Tem certeza de que deseja continuar?"
+
+#: globalPlugins/YoutubePlus/core.py:2170
+msgid "Confirm Clearing All Videos"
+msgstr "Confirmar a Remoção de Todos os Vídeos"
+
+#: globalPlugins/YoutubePlus/core.py:2174
+msgid "Clearing all feed videos..."
+msgstr "Limpando todos os vídeos do feed..."
+
+#: globalPlugins/YoutubePlus/core.py:2190
+#, python-brace-format
+msgid "Clearing complete. All {count} videos were deleted."
+msgstr "Limpeza concluída. Todos os {count} vídeos foram excluídos."
+
+#: globalPlugins/YoutubePlus/core.py:2195
+msgid "An error occurred while clearing all videos."
+msgstr "Ocorreu um erro ao limpar todos os vídeos."
+
+#: globalPlugins/YoutubePlus/core.py:2197
+msgid "an YoutubePlus layer commands."
+msgstr "comandos de camada do YoutubePlus."
+
+#: globalPlugins/YoutubePlus/core.py:2212
+#: globalPlugins/YoutubePlus/core.py:2221
+#: globalPlugins/YoutubePlus/core.py:2232
+#: globalPlugins/YoutubePlus/core.py:2246
+#: globalPlugins/YoutubePlus/core.py:2255
+msgid "YouTube URL not found in current window or clipboard."
+msgstr ""
+"URL do YouTube não encontrada na janela atual ou na área de transferência."
+
+#: globalPlugins/YoutubePlus/core.py:2224
+msgid "Getting video info..."
+msgstr "Obtendo informações do vídeo..."
+
+#: globalPlugins/YoutubePlus/core.py:2235
+#: globalPlugins/YoutubePlus/dialogs.py:967
+msgid "Getting chapters..."
+msgstr "Obtendo capítulos..."
+
+#: globalPlugins/YoutubePlus/core.py:2240
+msgid "Download subtitles from current page or clipboard URL."
+msgstr "Baixar legendas da página atual ou da URL da área de transferência."
+
+#: globalPlugins/YoutubePlus/core.py:2276
+msgid "No stream is currently being monitored."
+msgstr "Nenhuma transmissão está sendo monitorada no momento."
+
+#: globalPlugins/YoutubePlus/core.py:2286
+msgid "Automatic message speaking enabled."
+msgstr "Leitura automática de mensagens ativada."
+
+#: globalPlugins/YoutubePlus/core.py:2286
+msgid "Automatic message speaking disabled."
+msgstr "Leitura automática de mensagens desativada."
+
+#: globalPlugins/YoutubePlus/core.py:2288
+msgid "Show favorite videos dialog."
+msgstr "Exibir a caixa de diálogo de vídeos favoritos."
+
+#: globalPlugins/YoutubePlus/core.py:2295
+msgid "Show favorite channels dialog."
+msgstr "Exibir a caixa de diálogo de canais favoritos."
+
+#: globalPlugins/YoutubePlus/core.py:2302
+msgid "Show favorite playlists dialog."
+msgstr "Exibir a caixa de diálogo de playlists favoritas."
+
+#: globalPlugins/YoutubePlus/core.py:2309
+msgid "Show watch list dialog."
+msgstr "Exibir a caixa de diálogo da lista de reprodução."
+
+#: globalPlugins/YoutubePlus/core.py:2316
+msgid "Show a menu to add the current page URL to favorites or subscriptions."
+msgstr ""
+"Exibir um menu para adicionar a URL da página atual aos favoritos ou "
+"inscrições."
+
+#: globalPlugins/YoutubePlus/core.py:2321
+msgid "No specific YouTube URL found in the current window or clipboard."
+msgstr ""
+"Nenhuma URL específica do YouTube foi encontrada na janela atual ou na área "
+"de transferência."
+
+#: globalPlugins/YoutubePlus/core.py:2330
+msgid "Add to Favorite &Videos"
+msgstr "Adicionar aos &Vídeos Favoritos"
+
+#: globalPlugins/YoutubePlus/core.py:2332
+msgid "Add to Favorite &Channels"
+msgstr "Adicionar aos &Canais Favoritos"
+
+#: globalPlugins/YoutubePlus/core.py:2334
+msgid "Add to Favorite &Playlists"
+msgstr "Adicionar às &Playlists Favoritas"
+
+#: globalPlugins/YoutubePlus/core.py:2336
+msgid "&Subscribe to Channel"
+msgstr "Inscrever-se no &Canal"
+
+#: globalPlugins/YoutubePlus/core.py:2338
+#: globalPlugins/YoutubePlus/dialogs.py:916
+msgid "Add to &Watch List"
+msgstr "Adicionar à Lista de &Reprodução"
+
+#: globalPlugins/YoutubePlus/core.py:2376
+msgid "Show subscription feed dialog."
+msgstr "Exibir a caixa de diálogo do feed de inscrições."
+
+#: globalPlugins/YoutubePlus/core.py:2380
+msgid "Search YouTube for videos, channels, or playlists."
+msgstr "Pesquisar no YouTube por vídeos, canais ou playlists."
+
+#: globalPlugins/YoutubePlus/core.py:2387
+msgid "Show manage subscriptions dialog."
+msgstr "Exibir a caixa de diálogo de gerenciamento de inscrições."
+
+#: globalPlugins/YoutubePlus/core.py:2417
+msgid "Show user profile manager dialog."
+msgstr "Exibir a caixa de diálogo do gerenciador de perfil de usuário."
+
+#: globalPlugins/YoutubePlus/core.py:2424
+msgid "Opens YoutubePlus settings dialog."
+msgstr "Abre a caixa de diálogo de configurações do YoutubePlus."
+
+#: globalPlugins/YoutubePlus/core.py:2465
+msgid "manual"
+msgstr "manual"
+
+#: globalPlugins/YoutubePlus/core.py:2471
+msgid "auto"
+msgstr "auto"
+
+#: globalPlugins/YoutubePlus/core.py:2474
+msgid "No subtitles available for this video."
+msgstr "Nenhuma legenda disponível para este vídeo."
+
+#: globalPlugins/YoutubePlus/core.py:2481
+#, python-brace-format
+msgid "Failed to get subtitle info. Details: {}"
+msgstr "Falha ao obter informações de legenda. Detalhes: {}"
+
+#: globalPlugins/YoutubePlus/core.py:2494
+msgid "Select subtitle language:"
+msgstr "Selecione o idioma da legenda:"
+
+#: globalPlugins/YoutubePlus/core.py:2496
+#, python-brace-format
+msgid "Download subtitles: {title}"
+msgstr "Baixar legendas: {title}"
+
+#: globalPlugins/YoutubePlus/core.py:2516
+#, python-brace-format
+msgid "Downloading subtitles for {title}..."
+msgstr "Baixando legendas para {title}..."
+
+#: globalPlugins/YoutubePlus/core.py:2546
+#, python-brace-format
+msgid "Subtitles downloaded: {title}"
+msgstr "Legendas baixadas: {title}"
+
+#: globalPlugins/YoutubePlus/core.py:2549
+#, python-brace-format
+msgid "Subtitle download failed. Details: {}"
+msgstr "Falha no download da legenda. Detalhes: {}"
+
+#: globalPlugins/YoutubePlus/dialogs.py:84
+#: globalPlugins/YoutubePlus/dialogs.py:832
+msgid "Press Escape again to close."
+msgstr "Pressione Escape novamente para fechar."
+
+#: globalPlugins/YoutubePlus/dialogs.py:102
+#: globalPlugins/YoutubePlus/dialogs.py:245
+#: globalPlugins/YoutubePlus/dialogs.py:425
+#: globalPlugins/YoutubePlus/dialogs.py:671
+#: globalPlugins/YoutubePlus/dialogs.py:2867
+#: globalPlugins/YoutubePlus/dialogs.py:3071
+#: globalPlugins/YoutubePlus/dialogs.py:3206
+#: globalPlugins/YoutubePlus/dialogs.py:3424
+#: globalPlugins/YoutubePlus/dialogs.py:3736
+#: globalPlugins/YoutubePlus/dialogs.py:4388
+msgid "C&lose"
+msgstr "&Fechar"
+
+#: globalPlugins/YoutubePlus/dialogs.py:121
+msgid "YouTubePlus Help & Shortcuts"
+msgstr "Ajuda e &atalhos do YouTubePlus"
+
+#: globalPlugins/YoutubePlus/dialogs.py:129
+#| msgid ""
+#| "YouTubePlus Layer Commands (Press NVDA+Y to activate)\n"
+#| "\n"
+#| "--- Core Actions (from a YouTube window/URL) ---\n"
+#| "- L: Get comments from the current URL (Live Chat, Replay, or Comments)\n"
+#| "- I: Get video info\n"
+#| "- T: Show video chapters/timestamps\n"
+#| "- D: Download video/audio from the current URL\n"
+#| "- B: download sub title from the current URL\n"
+#| "- E: Search YouTube\n"
+#| "\n"
+#| "--- Favorites & Subscriptions ---\n"
+#| "- A: Show the \"Add to...\" menu (for favorites/subscriptions)\n"
+#| "- F: Show favorite videos dialog\n"
+#| "- C: Show favorite channels dialog\n"
+#| "- P: Show favorite playlists dialog\n"
+#| "- W: Show watch list dialog\n"
+#| "- S: Show subscription feed dialog\n"
+#| "- M: Show Manage Subscriptions dialog\n"
+#| "- U: Show User Profile Manager Dialog\n"
+#| "\n"
+#| "--- Live Chat Monitoring (while active) ---\n"
+#| "- Shift+L: Stop live chat monitoring\n"
+#| "- V: Show live chat messages dialog\n"
+#| "- R: Toggle automatic speaking of incoming messages\n"
+#| "- Y: open YoutubePlus settings dialog\n"
+#| "\n"
+#| "--- Additional Keyboard Shortcuts (within addon dialogs) ---\n"
+#| "**In Favorites and Subscription Feed Dialogs:**\n"
+#| "- Ctrl+1 through 9: Jump to a specific tab\n"
+#| "- Ctrl+Up/Down or Left/Right: Reorder tabs\n"
+#| "\n"
+#| "**In the Subscription Feed Dialog:**\n"
+#| "- F2: Rename the current category\n"
+#| "- Ctrl+Equals: Add a new category\n"
+#| "- Ctrl+Minus: Remove the current category\n"
+#| "- Delete: Mark the selected video as seen\n"
+#| "- Ctrl+Delete: Mark all videos in the current tab as seen\n"
+#| "\n"
+#| "**In any Favorites Dialog (Videos, Channels, Playlists, Watch list):**\n"
+#| "- Delete: Remove the selected item from favorites\n"
+#| "\n"
+#| "--- Help ---\n"
+#| "- H: Show this help dialog\n"
+msgid ""
+"YouTubePlus Layer Commands (Press NVDA+Y to activate)\n"
+"\n"
+"--- Core Actions (from a YouTube window/URL) ---\n"
+"- L: Get comments from the current URL (Live Chat, Replay, or Comments)\n"
+"- I: Get video info\n"
+"- T: Show video chapters/timestamps\n"
+"- D: Download video/audio from the current URL\n"
+"- B: download sub title from the current URL\n"
+"- E: Search YouTube\n"
+"\n"
+"--- Favorites & Subscriptions ---\n"
+"- A: Show the \"Add to...\" menu (for favorites/subscriptions)\n"
+"- F: Show favorite videos dialog\n"
+"- C: Show favorite channels dialog\n"
+"- P: Show favorite playlists dialog\n"
+"- W: Show watch list dialog\n"
+"- S: Show subscription feed dialog\n"
+"- M: Show Manage Subscriptions dialog\n"
+"- U: Show User Profile Manager Dialog\n"
+"\n"
+"--- Live Chat Monitoring (while active) ---\n"
+"- Shift+L: Stop live chat monitoring\n"
+"- V: Show live chat messages dialog\n"
+"- R: Toggle automatic speaking of incoming messages\n"
+"- Y: open YoutubePlus settings dialog\n"
+"\n"
+"--- Additional Keyboard Shortcuts (within addon dialogs) ---\n"
+"**In Favorites and Subscription Feed Dialogs:**\n"
+"- Ctrl+1 through 9: Jump to a specific tab\n"
+"- Ctrl+Up/Down or Left/Right: Reorder tabs\n"
+"\n"
+"**In the Subscription Feed Dialog:**\n"
+"- F2: Rename the current category\n"
+"- Ctrl+Equals: Add a new category\n"
+"- Ctrl+Minus: Remove the current category\n"
+"- Delete: Mark the selected video as seen\n"
+"- Ctrl+Delete: Mark all videos in the current tab as seen\n"
+"\n"
+"**In any Favorites Dialog (Videos, Channels, Playlists, Watch list):**\n"
+"- Delete: Remove the selected item from favorites\n"
+"- F2: rename item\n"
+"- Control+c / control+x > control+v : copy or cut then paste item to move "
+"position support multiple selection.\n"
+"\n"
+"--- Help ---\n"
+"- H: Show this help dialog\n"
+msgstr ""
+"Comandos da Camada do YouTubePlus (Pressione NVDA+Y para ativar)\n"
+"\n"
+"--- Ações Principais (a partir de uma janela/URL do YouTube) ---\n"
+"- L: Obter comentários da URL atual (Chat ao Vivo, Replay ou Comentários)\n"
+"- I: Obter informações do vídeo\n"
+"- T: Exibir capítulos/marcações de tempo do vídeo\n"
+"- D: Baixar vídeo/áudio da URL atual\n"
+"- B: Baixar legendas da URL atual\n"
+"- E: Pesquisar no YouTube\n"
+"\n"
+"--- Favoritos e Inscrições ---\n"
+"- A: Exibir o menu \"Adicionar a...\" (para favoritos/inscrições)\n"
+"- F: Exibir a caixa de diálogo de vídeos favoritos\n"
+"- C: Exibir a caixa de diálogo de canais favoritos\n"
+"- P: Exibir a caixa de diálogo de playlists favoritas\n"
+"- W: Exibir a caixa de diálogo da lista de reprodução posterior\n"
+"- S: Exibir a caixa de diálogo do feed de inscrições\n"
+"- M: Exibir a caixa de diálogo Gerenciar Inscrições\n"
+"- U: Exibir a caixa de diálogo Gerenciador de Perfis de Usuário\n"
+"\n"
+"--- Monitoramento do Chat ao Vivo (enquanto ativo) ---\n"
+"- Shift+L: Parar o monitoramento do chat ao vivo\n"
+"- V: Exibir a caixa de diálogo de mensagens do chat ao vivo\n"
+"- R: Alternar a leitura automática das mensagens recebidas\n"
+"- Y: Abrir a caixa de diálogo de configurações do YouTubePlus\n"
+"\n"
+"--- Atalhos de Teclado Adicionais (dentro das caixas de diálogo do "
+"complemento) ---\n"
+"**Nas caixas de diálogo de Favoritos e Feed de Inscrições:**\n"
+"- Ctrl+1 até 9: Ir para uma guia específica\n"
+"- Ctrl+Seta para Cima/Baixo ou Esquerda/Direita: Reordenar guias\n"
+"\n"
+"**Na caixa de diálogo Feed de Inscrições:**\n"
+"- F2: Renomear a categoria atual\n"
+"- Ctrl+=: Adicionar uma nova categoria\n"
+"- Ctrl+-: Remover a categoria atual\n"
+"- Delete: Marcar o vídeo selecionado como visto\n"
+"- Ctrl+Delete: Marcar todos os vídeos da guia atual como vistos\n"
+"\n"
+"**Em qualquer caixa de diálogo de Favoritos (Vídeos, Canais, Playlists, "
+"Lista de Reprodução Posterior):**\n"
+"- Delete: Remover o item selecionado dos favoritos\n"
+"- F2: Renomear item\n"
+"- Ctrl+C / Ctrl+X > Ctrl+V: Copiar ou recortar e depois colar o item para "
+"mover sua posição; suporta múltiplas seleções.\n"
+"\n"
+"--- Ajuda ---\n"
+"- H: Exibir esta caixa de diálogo de ajuda\n"
+
+#: globalPlugins/YoutubePlus/dialogs.py:188
+#: globalPlugins/YoutubePlus/dialogs.py:199
+msgid "Author"
+msgstr "Autor"
+
+#: globalPlugins/YoutubePlus/dialogs.py:190
+#: globalPlugins/YoutubePlus/dialogs.py:201
+msgid "Message"
+msgstr "Mensagem"
+
+#: globalPlugins/YoutubePlus/dialogs.py:192
+#: globalPlugins/YoutubePlus/dialogs.py:203
+#: globalPlugins/YoutubePlus/dialogs.py:229
+msgid "Time"
+msgstr "Tempo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:219
+#: globalPlugins/YoutubePlus/dialogs.py:407
+#: globalPlugins/YoutubePlus/dialogs.py:636
+#: globalPlugins/YoutubePlus/dialogs.py:2849
+msgid "&Search:"
+msgstr "&Procurar:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:227
+#: globalPlugins/YoutubePlus/dialogs.py:1264
+#: globalPlugins/YoutubePlus/dialogs.py:1390
+#: globalPlugins/YoutubePlus/dialogs.py:2663
+#: globalPlugins/YoutubePlus/dialogs.py:3061
+msgid "Title"
+msgstr "Título"
+
+#: globalPlugins/YoutubePlus/dialogs.py:237
+msgid "&Open Chapter"
+msgstr "&Abrir capítulo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:239
+msgid "&Copy Title"
+msgstr "&Copiar título"
+
+#: globalPlugins/YoutubePlus/dialogs.py:241
+msgid "Copy &URL"
+msgstr "Copiar &URL"
+
+#: globalPlugins/YoutubePlus/dialogs.py:243
+#: globalPlugins/YoutubePlus/dialogs.py:423
+#: globalPlugins/YoutubePlus/dialogs.py:663
+msgid "&Export"
+msgstr "&Exportar"
+
+#: globalPlugins/YoutubePlus/dialogs.py:325
+#: globalPlugins/YoutubePlus/dialogs.py:878
+msgid "Opening in browser..."
+msgstr "Abrindo no navegador..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:330
+#: globalPlugins/YoutubePlus/dialogs.py:884
+#, python-brace-format
+msgid "Error opening browser: {error}"
+msgstr "Erro ao abrir o navegador: {error}"
+
+#: globalPlugins/YoutubePlus/dialogs.py:340
+#, python-brace-format
+msgid "Copied timestamp: {text}"
+msgstr "Carimbo de data/hora copiado: {text}"
+
+#: globalPlugins/YoutubePlus/dialogs.py:349
+#, python-brace-format
+msgid "Copied URL: {url}"
+msgstr "URL copiado: {url}"
+
+#: globalPlugins/YoutubePlus/dialogs.py:367
+#: globalPlugins/YoutubePlus/dialogs.py:809
+msgid "Export complete"
+msgstr "Exportação concluída"
+
+#: globalPlugins/YoutubePlus/dialogs.py:371
+#: globalPlugins/YoutubePlus/dialogs.py:570
+#: globalPlugins/YoutubePlus/dialogs.py:813
+#, python-brace-format
+msgid "Error exporting file: {error}"
+msgstr "Erro ao exportar arquivo: {error}"
+
+#: globalPlugins/YoutubePlus/dialogs.py:375
+#: globalPlugins/YoutubePlus/dialogs.py:574
+#: globalPlugins/YoutubePlus/dialogs.py:817
+msgid "An unexpected error occurred during export."
+msgstr "Ocorreu um erro inesperado durante a exportação."
+
+#: globalPlugins/YoutubePlus/dialogs.py:421
+#: globalPlugins/YoutubePlus/dialogs.py:661
+msgid "&Copy"
+msgstr "&Copiar"
+
+#: globalPlugins/YoutubePlus/dialogs.py:546
+msgid "message copied"
+msgstr "mensagem copiada"
+
+#: globalPlugins/YoutubePlus/dialogs.py:549
+msgid "No message selected"
+msgstr "Nenhuma mensagem selecionada"
+
+#: globalPlugins/YoutubePlus/dialogs.py:566
+msgid "Export message complete"
+msgstr "Exportação de mensagem concluída"
+
+#: globalPlugins/YoutubePlus/dialogs.py:643
+#: globalPlugins/YoutubePlus/dialogs.py:650
+#: globalPlugins/YoutubePlus/dialogs.py:724
+msgid "No Filter"
+msgstr "Sem filtro"
+
+#: globalPlugins/YoutubePlus/dialogs.py:644
+#: globalPlugins/YoutubePlus/dialogs.py:717
+msgid "Filter by Selected Author"
+msgstr "Filtrar por autor selecionado"
+
+#: globalPlugins/YoutubePlus/dialogs.py:645
+#: globalPlugins/YoutubePlus/dialogs.py:726
+msgid "Show Super Chats Only"
+msgstr "Mostrar apenas Super Chats"
+
+#: globalPlugins/YoutubePlus/dialogs.py:646
+#: globalPlugins/YoutubePlus/dialogs.py:728
+msgid "Show Super Stickers Only"
+msgstr "Mostrar apenas super Stickers"
+
+#: globalPlugins/YoutubePlus/dialogs.py:647
+#: globalPlugins/YoutubePlus/dialogs.py:730
+msgid "Show Super Thanks Only"
+msgstr "Mostrar apenas agradecimentos especiais"
+
+#: globalPlugins/YoutubePlus/dialogs.py:707
+msgid "Total Paid Amount:\n"
+msgstr "Valor total pago:\\n\n"
+
+#: globalPlugins/YoutubePlus/dialogs.py:787
+#: globalPlugins/YoutubePlus/dialogs.py:1104
+#: globalPlugins/YoutubePlus/dialogs.py:3312
+msgid "Copied"
+msgstr "Copiado"
+
+#: globalPlugins/YoutubePlus/dialogs.py:790
+msgid "Nothing selected"
+msgstr "Nada selecionado"
+
+#: globalPlugins/YoutubePlus/dialogs.py:874
+#: globalPlugins/YoutubePlus/dialogs.py:948
+#: globalPlugins/YoutubePlus/dialogs.py:951
+#: globalPlugins/YoutubePlus/dialogs.py:962
+#: globalPlugins/YoutubePlus/dialogs.py:964
+#: globalPlugins/YoutubePlus/dialogs.py:1022
+#: globalPlugins/YoutubePlus/dialogs.py:1032
+#: globalPlugins/YoutubePlus/dialogs.py:1044
+#: globalPlugins/YoutubePlus/dialogs.py:1056
+msgid "Video ID not found."
+msgstr "ID do vídeo não encontrado."
+
+#: globalPlugins/YoutubePlus/dialogs.py:906
+msgid "View Video &Info..."
+msgstr "Ver vídeo e informações..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:907
+msgid "View &Comments / Replay..."
+msgstr "Ver &Comentários/Reproduzir..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:908
+msgid "View Chap&ters/Timestamps..."
+msgstr "Ver capítulos/carimbos de data/hora..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:910
+msgid "&Download Video"
+msgstr "&Baixar vídeo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:912
+msgid "Download Su&btitles"
+msgstr "Baixar legendas"
+
+#: globalPlugins/YoutubePlus/dialogs.py:914
+msgid "Add to &Favorite Videos"
+msgstr "Adicionar aos &Vídeos Favoritos"
+
+#: globalPlugins/YoutubePlus/dialogs.py:915
+msgid "Add to &Favorite Channels"
+msgstr "Adicionar aos canais &Favoritos"
+
+#: globalPlugins/YoutubePlus/dialogs.py:918
+msgid "&Open video in browser"
+msgstr "&Abrir vídeo no navegador"
+
+#: globalPlugins/YoutubePlus/dialogs.py:919
+msgid "Open c&hannel in browser"
+msgstr "Abrir &canal em um navegador"
+
+#: globalPlugins/YoutubePlus/dialogs.py:921
+msgid "Show channel &videos"
+msgstr "Mostrar canal e vídeos"
+
+#: globalPlugins/YoutubePlus/dialogs.py:922
+msgid "Show channel &shorts"
+msgstr "Mostrar canais e &shorts"
+
+#: globalPlugins/YoutubePlus/dialogs.py:923
+msgid "Show channel &live"
+msgstr "Mostrar canal e ao &vivo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:924
+#| msgid "Show channel &live"
+msgid "Show channel &playlist"
+msgstr "Mostrar playlist do &canal"
+
+#: globalPlugins/YoutubePlus/dialogs.py:925
+#| msgid "Show channel &videos"
+msgid "Show channel &podcast"
+msgstr "Mostrar &podcast do canal"
+
+#: globalPlugins/YoutubePlus/dialogs.py:954
+msgid "Getting subtitle info..."
+msgstr "Obtendo informações de legenda..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:975
+msgid "Could not get video ID to add to favorites."
+msgstr "Não foi possível obter o ID do vídeo para adicionar aos favoritos."
+
+#: globalPlugins/YoutubePlus/dialogs.py:985
+msgid "Could not get video ID to find the channel."
+msgstr "Não foi possível obter o ID do vídeo para encontrar o canal."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1090
+#: globalPlugins/YoutubePlus/dialogs.py:1097
+#: globalPlugins/YoutubePlus/dialogs.py:3307
+#, python-brace-format
+msgid "Title: {title}\n"
+msgstr "Título: {title}\n"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1091
+#: globalPlugins/YoutubePlus/dialogs.py:1098
+#, python-brace-format
+msgid "Channel: {channel}\n"
+msgstr "Canal: {channel}\\n\n"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1092
+#: globalPlugins/YoutubePlus/dialogs.py:1099
+#: globalPlugins/YoutubePlus/dialogs.py:3308
+msgid "URL: "
+msgstr "URL: "
+
+#: globalPlugins/YoutubePlus/dialogs.py:1113
+msgid "Error: Channel information not found for this item."
+msgstr "Erro: Informações do canal não encontradas para este item."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1123
+#: globalPlugins/YoutubePlus/dialogs.py:2149
+#: globalPlugins/YoutubePlus/dialogs.py:2398
+#: globalPlugins/YoutubePlus/dialogs.py:2667
+#: globalPlugins/YoutubePlus/dialogs.py:2826
+#: globalPlugins/YoutubePlus/dialogs.py:3063
+#: globalPlugins/YoutubePlus/dialogs.py:3190
+#: globalPlugins/YoutubePlus/dialogs.py:3404
+#: globalPlugins/YoutubePlus/dialogs.py:3644
+#: globalPlugins/YoutubePlus/dialogs.py:3819
+#: globalPlugins/YoutubePlus/settings.py:130
+msgid "Videos"
+msgstr "Vídeos"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1124
+#: globalPlugins/YoutubePlus/dialogs.py:2150
+#: globalPlugins/YoutubePlus/dialogs.py:3404
+#: globalPlugins/YoutubePlus/dialogs.py:3645
+#: globalPlugins/YoutubePlus/dialogs.py:3820
+#: globalPlugins/YoutubePlus/dialogs.py:3968
+#: globalPlugins/YoutubePlus/settings.py:130
+msgid "Shorts"
+msgstr "Shorts"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1125
+#: globalPlugins/YoutubePlus/dialogs.py:2151
+#: globalPlugins/YoutubePlus/dialogs.py:3404
+#: globalPlugins/YoutubePlus/dialogs.py:3646
+#: globalPlugins/YoutubePlus/dialogs.py:3821
+#: globalPlugins/YoutubePlus/dialogs.py:3969
+#: globalPlugins/YoutubePlus/settings.py:130
+msgid "Live"
+msgstr "Ao vivo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1126
+#: globalPlugins/YoutubePlus/dialogs.py:2152
+#: globalPlugins/YoutubePlus/dialogs.py:2828
+#: globalPlugins/YoutubePlus/dialogs.py:3647
+msgid "Playlists"
+msgstr "Listas de reprodução"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1127
+#: globalPlugins/YoutubePlus/dialogs.py:2153
+#: globalPlugins/YoutubePlus/dialogs.py:3648
+msgid "Podcasts"
+msgstr "Podcasts"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1131
+msgid "Content"
+msgstr "Contente"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1135
+#: globalPlugins/YoutubePlus/dialogs.py:2160
+#: globalPlugins/YoutubePlus/dialogs.py:3655
+#, python-brace-format
+msgid "Fetching {type} from {channel}..."
+msgstr "Buscando {type} de {channel}..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1230
+#: globalPlugins/YoutubePlus/dialogs.py:1962
+#: globalPlugins/YoutubePlus/dialogs.py:2409
+msgid "&Remove"
+msgstr "&Remover"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1268
+#: globalPlugins/YoutubePlus/dialogs.py:1394
+#: globalPlugins/YoutubePlus/dialogs.py:3063
+#: globalPlugins/YoutubePlus/dialogs.py:3919
+msgid "Duration"
+msgstr "Duração"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1270
+msgid "Upload Date"
+msgstr "Data de upload"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1274
+#: globalPlugins/YoutubePlus/dialogs.py:3067
+#: globalPlugins/YoutubePlus/dialogs.py:3923
+msgid "&Action..."
+msgstr "&Ação..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1276
+#: globalPlugins/YoutubePlus/dialogs.py:3068
+#: globalPlugins/YoutubePlus/dialogs.py:3202
+#: globalPlugins/YoutubePlus/dialogs.py:3925
+msgid "&Copy..."
+msgstr "&Copiar..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1301
+msgid "Error: Could not save data."
+msgstr "Erro: não foi possível salvar os dados."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1370
+#: globalPlugins/YoutubePlus/dialogs.py:3113
+#: globalPlugins/YoutubePlus/dialogs.py:3292
+#: globalPlugins/YoutubePlus/dialogs.py:4029
+msgid "Copy &Title"
+msgstr "Copiar &Título"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1371
+#: globalPlugins/YoutubePlus/dialogs.py:3115
+#: globalPlugins/YoutubePlus/dialogs.py:4031
+msgid "Copy Video &URL"
+msgstr "Copiar vídeo e &URL"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1372
+#: globalPlugins/YoutubePlus/dialogs.py:3117
+#: globalPlugins/YoutubePlus/dialogs.py:4033
+msgid "Copy &Channel Name"
+msgstr "Copiar &nome do canal"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1373
+#: globalPlugins/YoutubePlus/dialogs.py:3119
+#: globalPlugins/YoutubePlus/dialogs.py:4035
+msgid "Copy C&hannel URL"
+msgstr "Copiar URL do &canal"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1375
+#: globalPlugins/YoutubePlus/dialogs.py:3122
+#: globalPlugins/YoutubePlus/dialogs.py:3296
+#: globalPlugins/YoutubePlus/dialogs.py:4038
+msgid "Copy &Summary"
+msgstr "Copiar &Resumo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1396
+msgid "uploaded Date"
+msgstr "data de upload"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1398
+#: globalPlugins/YoutubePlus/dialogs.py:2241
+#: globalPlugins/YoutubePlus/dialogs.py:2669
+msgid "Date Added"
+msgstr "Data adicionada"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1408
+#: globalPlugins/YoutubePlus/dialogs.py:2247
+#: globalPlugins/YoutubePlus/dialogs.py:2675
+msgid "Sort List"
+msgstr "Lista de classificação"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1414
+#: globalPlugins/YoutubePlus/dialogs.py:2250
+#: globalPlugins/YoutubePlus/dialogs.py:2678
+msgid "Sort by:"
+msgstr "Ordenar por:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1429
+#: globalPlugins/YoutubePlus/dialogs.py:2262
+#: globalPlugins/YoutubePlus/dialogs.py:2690
+msgid "&Ascending"
+msgstr "&Ascendente"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1431
+#: globalPlugins/YoutubePlus/dialogs.py:2264
+#: globalPlugins/YoutubePlus/dialogs.py:2692
+msgid "&Descending"
+msgstr "&Descendente"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1441
+#: globalPlugins/YoutubePlus/dialogs.py:2272
+#: globalPlugins/YoutubePlus/dialogs.py:2700
+msgid "&Apply permanently (saves to file)"
+msgstr "&Aplicar permanentemente (salva em arquivo)"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1449
+#: globalPlugins/YoutubePlus/dialogs.py:2278
+#: globalPlugins/YoutubePlus/dialogs.py:2706
+msgid "C&lear Sort"
+msgstr "Limpar &classificação"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1480
+#: globalPlugins/YoutubePlus/dialogs.py:2303
+#: globalPlugins/YoutubePlus/dialogs.py:2731
+msgid "Sort cleared."
+msgstr "Classificação desmarcada."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1524
+#: globalPlugins/YoutubePlus/dialogs.py:2328
+#: globalPlugins/YoutubePlus/dialogs.py:2756
+msgid "List sorted and saved."
+msgstr "Lista classificada e salva."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1529
+#: globalPlugins/YoutubePlus/dialogs.py:2333
+#: globalPlugins/YoutubePlus/dialogs.py:2761
+msgid "List sorted temporarily."
+msgstr "Lista classificada temporariamente."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1543
+#: globalPlugins/YoutubePlus/dialogs.py:2529
+#, python-brace-format
+msgid "Are you sure you want to remove '{title}'?"
+msgstr "Tem certeza de que deseja remover '{title}'?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1546
+#, python-brace-format
+msgid "Are you sure you want to remove {count} selected items?"
+msgstr "Tem certeza de que deseja remover {count} itens selecionados?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1548
+#: globalPlugins/YoutubePlus/dialogs.py:2110
+#: globalPlugins/YoutubePlus/dialogs.py:2534
+#: globalPlugins/YoutubePlus/dialogs.py:4340
+msgid "Confirm Removal"
+msgstr "Confirmar remoção"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1566
+msgid "Item removed."
+msgstr "Item removido."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1567
+#, python-brace-format
+msgid "{count} items removed."
+msgstr "{count} itens removidos."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1574
+#: globalPlugins/YoutubePlus/dialogs.py:2020
+#: globalPlugins/YoutubePlus/dialogs.py:3673
+#: globalPlugins/YoutubePlus/dialogs.py:4054
+msgid "No valid YouTube URL found in clipboard."
+msgstr "Nenhum URL válido do YouTube encontrado na área de transferência."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1578
+#: globalPlugins/YoutubePlus/dialogs.py:2024
+#: globalPlugins/YoutubePlus/dialogs.py:2585
+#: globalPlugins/YoutubePlus/dialogs.py:3677
+#: globalPlugins/YoutubePlus/dialogs.py:4058
+msgid "Could not read from clipboard."
+msgstr "Não foi possível ler da área de transferência."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1596
+#, python-brace-format
+msgid "{count} item(s) copied."
+msgstr "{count} itens copiados."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1607
+#, python-brace-format
+msgid "{count} item(s) cut."
+msgstr "{count} item(s) cortado(s)."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1612
+#: globalPlugins/YoutubePlus/dialogs.py:2211
+#: globalPlugins/YoutubePlus/dialogs.py:2487
+msgid "Clipboard is empty."
+msgstr "A área de transferência está vazia."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1663
+msgid "Cut"
+msgstr "Cortar"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1663
+msgid "Copy"
+msgstr "Copiar"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1669
+#, python-brace-format
+msgid ""
+"{op} '{title}' from {src} to {dst} — this item already exists. Replace it?"
+msgstr "{op} '{title}' de {src} a {dst} — este item já existe. Substituí-lo?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1674
+#, python-brace-format
+msgid "{op} from {src} to {dst} — {count} item(s) already exist. Replace all?"
+msgstr "{op} de {src} a {dst} — {count} itens já existem. Substituir tudo?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1678
+msgid "Confirm Replace"
+msgstr "Confirmar substituição"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1743
+#, python-brace-format
+msgid "{count} item(s) pasted."
+msgstr "{count} itens colados."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1746
+#, python-brace-format
+msgid "{done} item(s) pasted, {skipped} skipped."
+msgstr "{done} item(s) colado(s), {skipped} ignorado."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1750
+msgid "All items already exist in this list."
+msgstr "Todos os itens já existem nesta lista."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1872
+msgid "Enter new title:"
+msgstr "Digite o novo título:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1874
+msgid "Rename"
+msgstr "Renomear"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1909
+msgid "Add &new favorite video from clipboard"
+msgstr "Adicione um novo vídeo favorito da área de transferência"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1922
+msgid "Add &new watch list from clipboard"
+msgstr "Adicionar &nova lista de observação da área de transferência"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1946
+#: globalPlugins/YoutubePlus/dialogs.py:2239
+msgid "Subscribers"
+msgstr "Assinantes"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1949
+msgid "Channel Description"
+msgstr "Descrição do canal"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1956
+msgid "Open channel on &browser"
+msgstr "Abrir canal no &navegador"
+
+#: globalPlugins/YoutubePlus/dialogs.py:1958
+msgid "View &channel Content..."
+msgstr "Ver conteúdo do &canal..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:1960
+msgid "Add &new favorite channel from clipboard"
+msgstr "Adicionar um novo canal favorito da área de transferência"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2103
+msgid "this channel"
+msgstr "este canal"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2105
+#, python-brace-format
+msgid "Are you sure you want to remove '{name}'?"
+msgstr "Tem certeza de que deseja remover '{name}'?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2108
+#, python-brace-format
+msgid "Are you sure you want to remove {count} selected channels?"
+msgstr "Tem certeza de que deseja remover {count} canais selecionados?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2130
+msgid "Channel removed."
+msgstr "Canal removido."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2131
+#, python-brace-format
+msgid "{count} channels removed."
+msgstr "{count} canais removidos."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2146
+#: globalPlugins/YoutubePlus/dialogs.py:3640
+msgid "Error: Channel URL not found."
+msgstr "Erro: URL do canal não encontrado."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2206
+#: globalPlugins/YoutubePlus/dialogs.py:2482
+msgid "Cut."
+msgstr "Cortar."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2232
+#: globalPlugins/YoutubePlus/dialogs.py:2508
+msgid "Moved."
+msgstr "Movido."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2355
+msgid "Enter new channel name:"
+msgstr "Digite o novo nome do canal:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2356
+msgid "Rename Channel"
+msgstr "Renomear canal"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2394
+#: globalPlugins/YoutubePlus/dialogs.py:3188
+msgid "Playlist Title"
+msgstr "Título da lista de reprodução"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2403
+#: globalPlugins/YoutubePlus/dialogs.py:3198
+msgid "Show &Videos..."
+msgstr "Mostrar &Vídeos..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2405
+msgid "Open on &browser"
+msgstr "Abrir no &navegador"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2407
+msgid "Add &new favorite playlist from clipboard"
+msgstr ""
+"Adicionar uma nova lista de reprodução favorita da área de transferência"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2527
+msgid "this playlist"
+msgstr "esta lista de reprodução"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2532
+#, python-brace-format
+msgid "Are you sure you want to remove {count} selected playlists?"
+msgstr "Tem certeza de que deseja remover {count} playlists selecionadas?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2554
+msgid "Playlist removed."
+msgstr "Lista de reprodução removida."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2555
+#, python-brace-format
+msgid "{count} playlists removed."
+msgstr "{count} playlists removidas."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2573
+msgid "Error: Could not save playlist list."
+msgstr "Erro: não foi possível salvar a lista de playlists."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2581
+msgid "No valid YouTube playlist URL found in clipboard."
+msgstr ""
+"Nenhum URL válido da lista de reprodução do YouTube foi encontrado na área "
+"de transferência."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2638
+#, python-brace-format
+msgid "Fetching videos from '{playlist}'..."
+msgstr "Buscando vídeos de '{playlist}'..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2783
+msgid "Enter new playlist title:"
+msgstr "Insira o novo título da lista de reprodução:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2784
+msgid "Rename Playlist"
+msgstr "Renomear lista de reprodução"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2820
+msgid "Favorites - YoutubePlus"
+msgstr "Favoritos - YoutubePlus"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2827
+msgid "Channels"
+msgstr "Canais"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2829
+msgid "Watch List"
+msgstr "Lista de observação"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2852
+msgid "S&ort..."
+msgstr "O&rganizar..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:2925
+#, python-brace-format
+msgid "{tab_name} - Favorites - YoutubePlus"
+msgstr "{tab_name} - Favoritos - YoutubePlus"
+
+#: globalPlugins/YoutubePlus/dialogs.py:2994
+msgid "Search YouTube"
+msgstr "Pesquise no YouTube"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3001
+msgid "&Search for:"
+msgstr "&Procurar:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3004
+msgid "Number of &results to fetch:"
+msgstr "Número de &resultados a serem buscados:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3010
+msgid "&Search"
+msgstr "&Procurar"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3038
+msgid "Please enter a search term."
+msgstr "Insira um termo de pesquisa."
+
+#: globalPlugins/YoutubePlus/dialogs.py:3070
+#: globalPlugins/YoutubePlus/dialogs.py:3204
+msgid "Load All"
+msgstr "Carregar tudo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3196
+#| msgid "Add to &Favorite Videos"
+msgid "Add to &Favorites"
+msgstr "Adicionar aos &Favoritos"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3200
+#| msgid "Open on &browser"
+msgid "Open on &Browser"
+msgstr "Abrir no &Navegador"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3268
+#: globalPlugins/YoutubePlus/dialogs.py:3337
+#| msgid "Error: Channel URL not found."
+msgid "Playlist URL not found."
+msgstr "URL da playlist não encontrado."
+
+#: globalPlugins/YoutubePlus/dialogs.py:3271
+#, python-brace-format
+#| msgid "Fetching videos from '{playlist}'..."
+msgid "Fetching videos from '{title}'..."
+msgstr "Obtendo vídeos de '{title}'..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:3294
+#| msgid "Copy &URL"
+msgid "Copy Playlist &URL"
+msgstr "Copiar &URL da Playlist"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3362
+msgid "Manage Subscriptions"
+msgstr "Gerenciar assinaturas"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3379
+msgid "Subscribed &Channels:"
+msgstr "Canais e inscritos:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3382
+#: globalPlugins/YoutubePlus/dialogs.py:3917
+msgid "Channel Name"
+msgstr "Nome do canal"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3387
+msgid "Filter by Category:"
+msgstr "Filtrar por categoria:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3396
+msgid "Assign to Categories"
+msgstr "Atribuir a categorias"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3401
+msgid "Content Types to Fetch"
+msgstr "Tipos de conteúdo para buscar"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3407
+msgid "Actions"
+msgstr "Ações"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3410
+msgid "View &Content..."
+msgstr "Ver &Conteúdo..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:3412
+msgid "Add &new subscribe channel from Clipboard..."
+msgstr "Adicionar &novo canal de inscrição na área de transferência..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:3414
+msgid "&Unsubscribe from this Channel"
+msgstr "&Cancelar inscrição neste canal"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3486
+#| msgid "Channel removed."
+msgid "Changes saved."
+msgstr "Alterações salvas."
+
+#: globalPlugins/YoutubePlus/dialogs.py:3518
+msgid "All Channels"
+msgstr "Todos os canais"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3688
+#, python-brace-format
+msgid "Are you sure you want to unsubscribe from '{name}'?"
+msgstr "Tem certeza de que deseja cancelar a assinatura de '{name}'?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3690
+#: globalPlugins/YoutubePlus/dialogs.py:4261
+msgid "Confirm Unsubscribe"
+msgstr "Confirmar cancelamento de inscrição"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3712
+msgid "Subscription Feed"
+msgstr "Feed de assinatura"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3730
+msgid "Add &new Subscription from clipboard URL."
+msgstr "Adicionar uma &nova assinatura do URL da área de transferência."
+
+#: globalPlugins/YoutubePlus/dialogs.py:3732
+msgid "&Update Feed"
+msgstr "&Atualizar feed"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3734
+msgid "&More..."
+msgstr "&Mais..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:3818
+msgid "All"
+msgstr "Todos"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3880
+msgid "Error reordering tabs."
+msgstr "Erro ao reordenar as guias."
+
+#: globalPlugins/YoutubePlus/dialogs.py:3905
+#, python-brace-format
+msgid "Subscription Feed - {tab_name} - YoutubePlus"
+msgstr "Feed de inscrição - {tab_name} - YoutubePlus"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3913
+msgid "Video Title"
+msgstr "Título do vídeo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3915
+msgid "Type"
+msgstr "Tipo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3927
+msgid "Mark as &Seen"
+msgstr "Marcar como &Visto"
+
+#: globalPlugins/YoutubePlus/dialogs.py:3967
+#: globalPlugins/YoutubePlus/dialogs.py:3976
+msgid "Video"
+msgstr "Vídeo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4069
+msgid "Mark &all in current tab as seen (control+delete)"
+msgstr "Marcar &tudo na guia atual como visto (control+delete)"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4071
+msgid "Show all &videos (including seen)"
+msgstr "Mostrar todos os &vídeos (incluindo os vistos)"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4071
+msgid "Show only &unseen videos"
+msgstr "Mostrar apenas vídeos &não vistos"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4074
+msgid "&Manage subscriptions..."
+msgstr "&Gerenciar assinaturas..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4077
+msgid "Add New &Category...\tCtrl+="
+msgstr "Adicionar nova &categoria...\tCtrl+="
+
+#: globalPlugins/YoutubePlus/dialogs.py:4079
+msgid "&Rename Current Category...\tF2"
+msgstr "&Renomear categoria atual...\tF2"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4081
+msgid "Remove Current Category...\tCtrl+-"
+msgstr "Remover categoria atual...\tCtrl+-"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4084
+msgid "Clear All Feed Videos..."
+msgstr "Limpar todos os vídeos do feed..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4122
+msgid "An update is already in progress."
+msgstr "Uma atualização já está em andamento."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4140
+#, python-brace-format
+msgid "Updating Feed ({count} channels)"
+msgstr "Atualizando feed ({count} canais)"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4142
+msgid "Starting..."
+msgstr "Começando..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4173
+msgid "&Unsubscribe from this channel"
+msgstr "&Cancelar inscrição neste canal"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4193
+msgid "Marked as seen."
+msgstr "Marcado como visto."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4201
+msgid "There are no videos in this tab to mark as seen."
+msgstr "Não há vídeos nesta guia para marcar como vistos."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4204
+#, python-brace-format
+msgid "Are you sure you want to mark all {count} videos in this tab as seen?"
+msgstr ""
+"Tem certeza de que deseja marcar todos os {count} vídeos nesta guia como "
+"vistos?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4206
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4212
+msgid "All videos in the current tab have been marked as seen."
+msgstr "Todos os vídeos na guia atual foram marcados como vistos."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4259
+#, python-brace-format
+msgid "Are you sure you want to unsubscribe from '{channel}'?"
+msgstr "Tem certeza de que deseja cancelar a inscrição em '{channel}'?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4269
+msgid "Enter new category name:"
+msgstr "Insira o novo nome da categoria:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4271
+msgid "Add Category"
+msgstr "Adicionar categoria"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4288
+#: globalPlugins/YoutubePlus/dialogs.py:4321
+msgid "A category with this name already exists."
+msgstr "Já existe uma categoria com este nome."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4292
+msgid "Error adding category."
+msgstr "Erro ao adicionar categoria."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4300
+msgid "This is a fixed tab and cannot be renamed."
+msgstr "Esta é uma guia fixa e não pode ser renomeada."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4305
+#, python-brace-format
+msgid "Enter new name for '{name}':"
+msgstr "Digite o novo nome para '{name}':"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4307
+msgid "Rename Category"
+msgstr "Renomear categoria"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4325
+msgid "Error renaming category."
+msgstr "Erro ao renomear categoria."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4333
+msgid "This is a fixed tab and cannot be removed."
+msgstr "Esta é uma guia fixa e não pode ser removida."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4338
+#, python-brace-format
+msgid "Are you sure you want to remove the '{name}' category?"
+msgstr "Tem certeza de que deseja remover a categoria '{name}'?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4351
+#, python-brace-format
+msgid "Category '{name}' removed."
+msgstr "Categoria '{name}' removida."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4355
+msgid "Error removing category."
+msgstr "Erro ao remover categoria."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4362
+msgid "Manage User Profiles"
+msgstr "Gerenciar perfis de usuário"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4374
+msgid "&Add"
+msgstr "&Adicionar"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4376
+msgid "&Rename"
+msgstr "&Renomear"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4378
+msgid "&Delete"
+msgstr "&Excluir"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4421
+msgid "Enter new profile name:"
+msgstr "Digite o novo nome do perfil:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4423
+msgid "Add Profile"
+msgstr "Adicionar perfil"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4439
+msgid "Profile already exists."
+msgstr "O perfil já existe."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4439
+#: globalPlugins/YoutubePlus/dialogs.py:4457
+#: globalPlugins/YoutubePlus/dialogs.py:4471
+#: globalPlugins/YoutubePlus/dialogs.py:4478
+#: globalPlugins/YoutubePlus/dialogs.py:4483
+#: globalPlugins/YoutubePlus/dialogs.py:4498
+msgid "Error"
+msgstr "Erro"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4445
+#, python-brace-format
+msgid "Rename profile '{name}' to:"
+msgstr "Renomeie o perfil '{name}' para:"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4447
+msgid "Rename Profile"
+msgstr "Renomear perfil"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4457
+msgid "A profile with this name already exists."
+msgstr "Já existe um perfil com este nome."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4471
+#, python-brace-format
+msgid "Failed to rename profile: {e}"
+msgstr "Falha ao renomear perfil: {e}"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4478
+msgid "The default profile cannot be deleted."
+msgstr "O perfil padrão não pode ser excluído."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4483
+msgid "Cannot delete the profile currently in use."
+msgstr "Não é possível excluir o perfil atualmente em uso."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4486
+#, python-brace-format
+msgid "Delete profile '{name}' and all its data?"
+msgstr "Excluir o perfil '{name}' e todos os seus dados?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4488
+msgid "Confirm Delete"
+msgstr "Confirmar exclusão"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4498
+#, python-brace-format
+msgid "Failed to delete profile: {e}"
+msgstr "Falha ao excluir perfil: {e}"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4507
+msgid ""
+"The active profile has been modified. NVDA must be restarted to apply "
+"changes. Restart now?"
+msgstr ""
+"O perfil ativo foi modificado. O NVDA deve ser reiniciado para aplicar as "
+"alterações. Reiniciar agora?"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4509
+#: globalPlugins/YoutubePlus/settings.py:285
+msgid "Restart NVDA"
+msgstr "Reinicie o NVDA"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4524
+msgid "Downloading..."
+msgstr "Baixando..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4538
+msgid "Field"
+msgstr "Campo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4539
+msgid "Value"
+msgstr "Valor"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4542
+msgid "File"
+msgstr "Arquivo"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4543
+msgid "Progress"
+msgstr "Progresso"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4544
+msgid "Size"
+msgstr "Tamanho"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4545
+msgid "Speed"
+msgstr "Velocidade"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4546
+msgid "ETA"
+msgstr "E"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4547
+msgid "Status"
+msgstr "Status"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4553
+msgid "Preparing..."
+msgstr "Preparando..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4564
+msgid "&Cancel"
+msgstr "&Cancelar"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4623
+#, python-brace-format
+msgid "Downloading: {title}"
+msgstr "Baixando: {title}"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4644
+#, python-brace-format
+msgid "{pct}%"
+msgstr "{pct}%"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4651
+#: globalPlugins/YoutubePlus/dialogs.py:4662
+msgid "Downloading"
+msgstr "Baixando"
+
+#: globalPlugins/YoutubePlus/dialogs.py:4670
+msgid "Finishing..."
+msgstr "Acabando..."
+
+#: globalPlugins/YoutubePlus/dialogs.py:4687
+msgid "Cancelling..."
+msgstr "Cancelando..."
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:134
+#, python-format
+msgid "no such option: %s"
+msgstr "não existe essa opção: %s"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:145
+#, python-format
+msgid "ambiguous option: %s (%s?)"
+msgstr "opção ambígua: %s (%s?)"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:371
+#, python-format
+msgid "Usage: %s\n"
+msgstr "Uso: %s\\n\n"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:390
+#| msgid "Message"
+msgid "Usage"
+msgstr "Uso"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:412
+#: globalPlugins/YoutubePlus/lib/optparse.py:413
+msgid "integer"
+msgstr "inteiro"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:414
+msgid "floating-point"
+msgstr "ponto flutuante"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:415
+msgid "complex"
+msgstr "complexo"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:423
+#, python-format
+msgid "option %s: invalid %s value: %r"
+msgstr "opção %s: valor %s inválido: %r"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:431
+#, python-format
+msgid "option %s: invalid choice: %r (choose from %s)"
+msgstr "opção %s: escolha inválida: %r (escolha entre %s)"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:1228
+msgid "show this help message and exit"
+msgstr "mostrar esta mensagem de ajuda e sair"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:1233
+msgid "show program's version number and exit"
+msgstr "mostrar o número da versão do programa e sair"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:1256
+msgid "%prog [options]"
+msgstr "%prog [opções]"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:1476
+#: globalPlugins/YoutubePlus/lib/optparse.py:1514
+#, python-format
+msgid "%(option)s option requires %(number)d argument"
+msgid_plural "%(option)s option requires %(number)d arguments"
+msgstr[0] "A opção %(option)s requer %(number)d argumento"
+msgstr[1] "%(option)s option requires %(number)d arguments"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:1486
+#, python-format
+msgid "%s option does not take a value"
+msgstr "A opção %s não aceita um valor"
+
+#: globalPlugins/YoutubePlus/lib/optparse.py:1602
+#| msgid "Actions"
+msgid "Options"
+msgstr "Opções"
+
+#: globalPlugins/YoutubePlus/settings.py:24
+msgid "Youtube Plus"
+msgstr "YouTube Mais"
+
+#: globalPlugins/YoutubePlus/settings.py:30
+msgid "Active &Profile (Requires Restart):"
+msgstr "&Perfil ativo (requer reinicialização):"
+
+#: globalPlugins/YoutubePlus/settings.py:36
+#: globalPlugins/YoutubePlus/settings.py:259
+#: globalPlugins/YoutubePlus/settings.py:264
+msgid "default"
+msgstr "padrão"
+
+#: globalPlugins/YoutubePlus/settings.py:41
+msgid "&Manage Profiles..."
+msgstr "&Gerenciar perfis..."
+
+#: globalPlugins/YoutubePlus/settings.py:45
+msgid "&Quick Action (Space bar):"
+msgstr "&Ação rápida (barra de espaço):"
+
+#: globalPlugins/YoutubePlus/settings.py:48
+msgid "Open video URL"
+msgstr "Abrir URL do vídeo"
+
+#: globalPlugins/YoutubePlus/settings.py:50
+msgid "View video info"
+msgstr "Ver informações do vídeo"
+
+#: globalPlugins/YoutubePlus/settings.py:52
+msgid "View comments"
+msgstr "Ver comentários"
+
+#: globalPlugins/YoutubePlus/settings.py:54
+msgid "View chapters"
+msgstr "Ver capítulos"
+
+#: globalPlugins/YoutubePlus/settings.py:56
+msgid "Download video"
+msgstr "Baixar vídeo"
+
+#: globalPlugins/YoutubePlus/settings.py:58
+msgid "Download audio"
+msgstr "Baixar áudio"
+
+#: globalPlugins/YoutubePlus/settings.py:60
+msgid "Download subtitles"
+msgstr "Baixar legendas"
+
+#: globalPlugins/YoutubePlus/settings.py:62
+msgid "Add to Favorites video"
+msgstr "Adicionar vídeo aos favoritos"
+
+#: globalPlugins/YoutubePlus/settings.py:64
+msgid "Add to Favorites channel"
+msgstr "Adicionar ao canal Favoritos"
+
+#: globalPlugins/YoutubePlus/settings.py:66
+msgid "Add to Watch List"
+msgstr "Adicionar à lista de observação"
+
+#: globalPlugins/YoutubePlus/settings.py:68
+msgid "Copy video URL"
+msgstr "Copiar URL do vídeo"
+
+#: globalPlugins/YoutubePlus/settings.py:70
+msgid "Copy video title"
+msgstr "Copiar título do vídeo"
+
+#: globalPlugins/YoutubePlus/settings.py:72
+msgid "Copy channel name"
+msgstr "Copiar nome do canal"
+
+#: globalPlugins/YoutubePlus/settings.py:74
+msgid "Copy channel URL"
+msgstr "Copiar URL do canal"
+
+#: globalPlugins/YoutubePlus/settings.py:76
+msgid "Copy video summary"
+msgstr "Copiar resumo do vídeo"
+
+#: globalPlugins/YoutubePlus/settings.py:78
+msgid "Open video channel"
+msgstr "Abrir canal de vídeo"
+
+#: globalPlugins/YoutubePlus/settings.py:80
+msgid "Show channel videos"
+msgstr "Mostrar vídeos do canal"
+
+#: globalPlugins/YoutubePlus/settings.py:82
+msgid "Show channel shorts"
+msgstr "Mostrar shorts do canal"
+
+#: globalPlugins/YoutubePlus/settings.py:84
+msgid "Show channel lives"
+msgstr "Mostrar lives do canal"
+
+#: globalPlugins/YoutubePlus/settings.py:86
+#| msgid "Show channel lives"
+msgid "Show channel playlists"
+msgstr "Mostrar playlists do canal"
+
+#: globalPlugins/YoutubePlus/settings.py:88
+#| msgid "Show channel shorts"
+msgid "Show channel podcasts"
+msgstr "Mostrar podcasts do canal"
+
+#: globalPlugins/YoutubePlus/settings.py:105
+msgid "&Notification mode:"
+msgstr "&Modo de notificação:"
+
+#: globalPlugins/YoutubePlus/settings.py:108
+msgid "Beep"
+msgstr "Bip"
+
+#: globalPlugins/YoutubePlus/settings.py:108
+msgid "Sound"
+msgstr "Som"
+
+#: globalPlugins/YoutubePlus/settings.py:108
+msgid "Silent"
+msgstr "Silencioso"
+
+#: globalPlugins/YoutubePlus/settings.py:115
+msgid "Default &sort order:"
+msgstr "Ordem padrão e de classificação:"
+
+#: globalPlugins/YoutubePlus/settings.py:117
+msgid "Newest First"
+msgstr "Mais novo primeiro"
+
+#: globalPlugins/YoutubePlus/settings.py:117
+msgid "Oldest First"
+msgstr "Mais antigo primeiro"
+
+#: globalPlugins/YoutubePlus/settings.py:124
+msgid "&Items to fetch for each content type:"
+msgstr "&Itens a serem buscados para cada tipo de conteúdo:"
+
+#: globalPlugins/YoutubePlus/settings.py:128
+msgid "Default content &types for new subscriptions:"
+msgstr "Conteúdo e tipos padrão para novas assinaturas:"
+
+#: globalPlugins/YoutubePlus/settings.py:143
+msgid "Disabled"
+msgstr "Desabilitado"
+
+#: globalPlugins/YoutubePlus/settings.py:143
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#: globalPlugins/YoutubePlus/settings.py:143
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#: globalPlugins/YoutubePlus/settings.py:143
+msgid "1 hour"
+msgstr "1 hora"
+
+#: globalPlugins/YoutubePlus/settings.py:143
+msgid "2 hours"
+msgstr "2 horas"
+
+#: globalPlugins/YoutubePlus/settings.py:144
+msgid "4 hours"
+msgstr "4 horas"
+
+#: globalPlugins/YoutubePlus/settings.py:144
+msgid "6 hours"
+msgstr "6 horas"
+
+#: globalPlugins/YoutubePlus/settings.py:144
+msgid "12 hours"
+msgstr "12 horas"
+
+#: globalPlugins/YoutubePlus/settings.py:144
+msgid "24 hours"
+msgstr "24 horas"
+
+#: globalPlugins/YoutubePlus/settings.py:148
+msgid "Background &update interval:"
+msgstr "Intervalo de atualização e plano de fundo:"
+
+#: globalPlugins/YoutubePlus/settings.py:159
+msgid "&Automatically speak incoming live chat"
+msgstr "&Falar automaticamente o bate-papo ao vivo recebido"
+
+#: globalPlugins/YoutubePlus/settings.py:163
+msgid "&Live chat refresh interval (seconds):"
+msgstr "&Intervalo de atualização do chat ao vivo (segundos):"
+
+#: globalPlugins/YoutubePlus/settings.py:167
+msgid "Message &history limit (live chat):"
+msgstr "Limite de mensagens e histórico (chat ao vivo):"
+
+#: globalPlugins/YoutubePlus/settings.py:195
+msgid "&Cookie method (Experimental - may not work):"
+msgstr "Método &Cookie (Experimental - pode não funcionar):"
+
+#: globalPlugins/YoutubePlus/settings.py:197
+msgid "Do not use cookies (Default)"
+msgstr "Não use cookies (padrão)"
+
+#: globalPlugins/YoutubePlus/settings.py:198
+msgid "Chrome"
+msgstr "Chrome"
+
+#: globalPlugins/YoutubePlus/settings.py:199
+msgid "Firefox"
+msgstr "Firefox"
+
+#: globalPlugins/YoutubePlus/settings.py:200
+msgid "Edge"
+msgstr "Edge"
+
+#: globalPlugins/YoutubePlus/settings.py:201
+msgid "Opera"
+msgstr "Opera"
+
+#: globalPlugins/YoutubePlus/settings.py:202
+msgid "Brave"
+msgstr "Brave"
+
+#: globalPlugins/YoutubePlus/settings.py:203
+msgid "Vivaldi"
+msgstr "Vivaldi"
+
+#: globalPlugins/YoutubePlus/settings.py:222
+msgid "Default subtitle &format:"
+msgstr "Legenda e &formato padrão:"
+
+#: globalPlugins/YoutubePlus/settings.py:232
+msgid "Default download and &export folder path:"
+msgstr "Caminho padrão da pasta de download e exportação:"
+
+#: globalPlugins/YoutubePlus/settings.py:237
+msgid "&Browse..."
+msgstr "&Navegar..."
+
+#: globalPlugins/YoutubePlus/settings.py:243
+msgid "Bac&kup data now"
+msgstr "Dados de b&ackup agora"
+
+#: globalPlugins/YoutubePlus/settings.py:247
+msgid "&Restore data from backup..."
+msgstr "&Restaurar dados do backup..."
+
+#: globalPlugins/YoutubePlus/settings.py:283
+#, python-brace-format
+msgid ""
+"The active profile has been changed to '{profile_name}'. NVDA must be "
+"restarted to apply this change. Restart now?"
+msgstr ""
+"O perfil ativo foi alterado para '{profile_name}'. O NVDA deve ser "
+"reiniciado para aplicar esta alteração. Reiniciar agora?"
+
+#: globalPlugins/YoutubePlus/settings.py:343
+msgid "Select cookies.txt file"
+msgstr "Selecione o arquivo cookies.txt"
+
+#: globalPlugins/YoutubePlus/settings.py:354
+msgid "Select default folder to export files"
+msgstr "Selecione a pasta padrão para exportar arquivos"
+
+#: globalPlugins/YoutubePlus/settings.py:365
+#, python-brace-format
+msgid ""
+"Backup completed successfully.\n"
+"{filename}"
+msgstr ""
+"Backup concluído com sucesso.\\n\n"
+"{filename}"
+
+#: globalPlugins/YoutubePlus/settings.py:367
+msgid "Backup"
+msgstr "Backup"
+
+#: globalPlugins/YoutubePlus/settings.py:373
+#, python-brace-format
+msgid "Backup failed: {error}"
+msgstr "Falha no backup: {error}"
+
+#: globalPlugins/YoutubePlus/settings.py:375
+msgid "Backup Error"
+msgstr "Erro de backup"
+
+#: globalPlugins/YoutubePlus/settings.py:385
+#, python-brace-format
+msgid "No backup files found for profile '{profile}'."
+msgstr "Nenhum arquivo de backup encontrado para o perfil '{profile}'."
+
+#: globalPlugins/YoutubePlus/settings.py:387
+msgid "Restore"
+msgstr "Restaurar"
+
+#: globalPlugins/YoutubePlus/settings.py:405
+#, python-brace-format
+msgid ""
+"Restore data from {date} for profile '{profile}'?\n"
+"This will overwrite all current data and requires a restart."
+msgstr ""
+"Restaurar dados de {date} para o perfil '{profile}'?\\n\n"
+"Isso substituirá todos os dados atuais e exigirá uma reinicialização."
+
+#: globalPlugins/YoutubePlus/settings.py:408
+msgid "Confirm Restore"
+msgstr "Confirmar restauração"
+
+#: globalPlugins/YoutubePlus/settings.py:415
+msgid ""
+"YoutubePlus Data restored successfully. NVDA must be restarted to apply the "
+"changes. Restart now?"
+msgstr ""
+"Dados do YoutubePlus restaurados com sucesso. O NVDA deve ser reiniciado "
+"para aplicar as alterações. Reiniciar agora?"
+
+#: globalPlugins/YoutubePlus/settings.py:420
+#, python-brace-format
+msgid "Restore failed: {error}"
+msgstr "Falha na restauração: {error}"
+
+#: globalPlugins/YoutubePlus/settings.py:422
+msgid "Restore Error"
+msgstr "Erro de restauração"
+
+#~ msgid "Successfully migrated {count} data files to the user directory."
+#~ msgstr ""
+#~ "Arquivos de dados {count} migrados com sucesso para o diretório do "
+#~ "usuário."
+
+#~ msgid "YouTube Plus Migration"
+#~ msgstr "Migração do YouTube Plus"
+
+#~| msgid "Starting download of {title}..."
+#~ msgid "Getting data for '{title}'..."
+#~ msgstr "Obtendo dados para '{title}'..."
+
+#~ msgid "&Save Changes"
+#~ msgstr "&Salvar alterações"
+
+#~| msgid "No channels to update."
+#~ msgid "No channel selected to save."
+#~ msgstr "Nenhum canal selecionado para salvar."
+
+#~ msgid "Changes saved for the selected channel."
+#~ msgstr "Alterações salvas para o canal selecionado."
+
+#~| msgid "Error updating feed."
+#~ msgid "Error saving changes."
+#~ msgstr "Erro ao salvar as alterações."


### PR DESCRIPTION
Add Brazilian Portuguese user documentation and locale messages for YoutubePlus. Creates addon/doc/pt_BR/readme.md with a full Portuguese user guide, keyboard shortcuts and feature descriptions, and adds addon/locale/pt_BR/LC_MESSAGES/nvda.po containing the pt_BR translations for NVDA strings (Poedit metadata and ~2559 entries).